### PR TITLE
postinst: only touch systemd when it's actually running

### DIFF
--- a/debian/hifiberry-configurator.postinst
+++ b/debian/hifiberry-configurator.postinst
@@ -10,8 +10,9 @@ case "$1" in
         chown root:root /etc/configserver/configserver.json 2>/dev/null || true
         chmod 644 /etc/configserver/configserver.json 2>/dev/null || true
         
-        # Enable and start the config-server service
-        if command -v systemctl >/dev/null 2>&1; then
+        # Only touch systemd when it's actually running (PID 1), not just when
+        # the systemctl binary exists — otherwise this aborts in build chroots.
+        if [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1; then
             # Reload systemd daemon to recognize new service
             systemctl daemon-reload
             


### PR DESCRIPTION
### What

Guard the systemd block in `debian/hifiberry-configurator.postinst` on a
*running* systemd (`[ -d /run/systemd/system ]`), not just on the `systemctl`
binary being present.

### Why

When the package is installed in a build chroot (debootstrap, `rpi-image-gen`,
docker, pi-gen) `systemctl` exists but systemd is not PID 1. The current guard
(`command -v systemctl`) passes, then `systemctl daemon-reload` fails with
"System has not been booted with systemd as init system. Can't operate." — and
because the script runs under `set -e`, that aborts the whole postinst. The
package is left unconfigured, which cascades to everything depending on it
(`hbos-minimal`, `hifiberry-shairport`, `hifiberry-mpd`, `hifiberry-librespot`).

Hit this building a HiFiBerryOS image with `rpi-image-gen` on Trixie.

### Note

This just aligns `hifiberry-configurator` with the sibling packages whose
postinsts already guard the same way — `hifiberry-shairport`, `hifiberry-mpd`,
and `hifiberry-audiocontrol` all use `if [ -d /run/systemd/system ]`. Behaviour
on a real boot is unchanged; the first-boot enable is otherwise handled by the
`#DEBHELPER#` block (which already guards on `/run/systemd/system`).

I left the version/changelog alone for you to bump at release time.