### PR TITLE
debian: unify systemd handling under dh_installsystemd

### DIFF
--- a/debian/hifiberry-configurator.postinst
+++ b/debian/hifiberry-configurator.postinst
@@ -5,46 +5,15 @@ case "$1" in
     configure)
         # Create config directory (should already exist from package installation)
         mkdir -p /etc/configserver
-        
+
         # Set proper permissions on config files
         chown root:root /etc/configserver/configserver.json 2>/dev/null || true
         chmod 644 /etc/configserver/configserver.json 2>/dev/null || true
-        
-        # Only touch systemd when it's actually running (PID 1), not just when
-        # the systemctl binary exists — otherwise this aborts in build chroots.
-        if [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1; then
-            # Reload systemd daemon to recognize new service
-            systemctl daemon-reload
-            
-            # Enable the config-server service for automatic startup
-            systemctl enable config-server.service
-            
-            # Enable the config-detect service for automatic startup
-            systemctl enable config-detect.service
-
-            # Enable create-uuid.service so /etc/uuid is created on every boot
-            # (no-op when the file already exists). Required by services that
-            # depend on /etc/uuid (e.g. raat for Roon).
-            if systemctl list-unit-files create-uuid.service >/dev/null 2>&1; then
-                systemctl enable create-uuid.service
-                # Trigger it now too so /etc/uuid exists immediately after install.
-                systemctl start create-uuid.service || true
-            fi
-
-            # Start the config-server service if not already running
-            if ! systemctl is-active --quiet config-server.service; then
-                systemctl start config-server.service
-            fi
-            
-            echo "HiFiBerry Configuration Server has been enabled and started."
-            echo "HiFiBerry Sound Card Detection service has been enabled."
-            echo "The API is available at http://localhost:1081"
-        fi
         ;;
-    
+
     abort-upgrade|abort-remove|abort-deconfigure)
         ;;
-    
+
     *)
         echo "postinst called with unknown argument \`$1'" >&2
         exit 1

--- a/debian/hifiberry-configurator.prerm
+++ b/debian/hifiberry-configurator.prerm
@@ -1,38 +1,4 @@
 #!/bin/bash
 set -e
 
-case "$1" in
-    remove|purge)
-        # Stop and disable the services
-        if command -v systemctl >/dev/null 2>&1; then
-            # Stop and disable config-server service
-            if systemctl is-active --quiet config-server.service; then
-                systemctl stop config-server.service
-            fi
-            
-            if systemctl is-enabled --quiet config-server.service; then
-                systemctl disable config-server.service
-            fi
-            
-            # Stop and disable config-detect service
-            if systemctl is-enabled --quiet config-detect.service; then
-                systemctl disable config-detect.service
-            fi
-            
-            # Reload systemd daemon
-            systemctl daemon-reload
-            
-            echo "HiFiBerry Configuration Server and Detection services have been stopped and disabled."
-        fi
-        ;;
-    
-    upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
-        ;;
-    
-    *)
-        echo "prerm called with unknown argument \`$1'" >&2
-        exit 1
-        ;;
-esac
-
 #DEBHELPER#

--- a/debian/rules
+++ b/debian/rules
@@ -4,5 +4,4 @@
 	dh $@ --buildsystem=pybuild
 
 override_dh_installsystemd:
-	dh_installsystemd --no-restart-after-upgrade --no-stop-on-upgrade --name=config-detect
-	dh_installsystemd --remaining-packages
+	dh_installsystemd --no-restart-after-upgrade --no-stop-on-upgrade


### PR DESCRIPTION
Closes #5. See the commit message for the full diagnosis (`--remaining-packages` was a no-op, hand-rolled postinst masked it on live systems but skipped offline) and the reasoning behind the fix shape.

## Verification (mmdebstrap chroot, arm64 Trixie)

```sh
$ sudo chroot /tmp/cfg-chroot dpkg -i --force-depends /tmp/hifiberry-configurator_2.13.15_all.deb
...
Setting up hifiberry-configurator (2.13.15) ...

$ sudo find /tmp/cfg-chroot/etc/systemd/system -name '*.service' -o -name '*.timer' | sort
.../multi-user.target.wants/ble-provisioning.service
.../multi-user.target.wants/config-detect.service
.../multi-user.target.wants/config-server.service     ← previously missing
.../multi-user.target.wants/create-uuid.service
.../multi-user.target.wants/sambamount.service
.../multi-user.target.wants/volume-restore.service
.../multi-user.target.wants/volume-store.service
.../timers.target.wants/volume-store.timer
```

All eight wants-symlinks present, including `config-server.service` — the regression from #5 reproduced and fixed in the same environment.