### PR TITLE
debian/control: add missing dependency on uuid

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Homepage: https://www.hifiberry.com/
 
 Package: hifiberry-configurator
 Architecture: all
-Depends: ${python3:Depends}, ${misc:Depends}, systemd, hifiberry-eeprom, python3-netifaces, python3-dbus, python3-argcomplete, python3-waitress, python3-bless, avahi-daemon
+Depends: ${python3:Depends}, ${misc:Depends}, systemd, hifiberry-eeprom, python3-netifaces, python3-dbus, python3-argcomplete, python3-waitress, python3-bless, avahi-daemon, uuid
 Recommends: samba-common-bin, smbclient
 Description: HiFiBerry system configuration scripts
  System configuration scripts for HiFiBerry OS, including


### PR DESCRIPTION
`create-uuid.service` runs `/usr/bin/uuid > /etc/uuid`, but the package does not declare a dependency on the `uuid` package (from `ossp-uuid` in Debian) that ships that binary. On any image where `uuid` isn't pulled in by something else, the unit fails at boot:

```
create-uuid.service: Main process exited, code=exited, status=127
/bin/sh: 1: /usr/bin/uuid: not found
```

Spotted while debugging a related offline-install issue on a mmdebstrap-built HiFiBerry-OS image — `uuid-dev` was present (a transitive build-dep) but the `uuid` runtime package was not, and `/usr/bin/uuid` only comes from `uuid`.

This PR is independent of #6 and can be merged separately.