### PR TITLE
Generic plugin-settings capability for external players

### DIFF
--- a/configurator/configdb.py
+++ b/configurator/configdb.py
@@ -12,7 +12,12 @@ import logging
 import argparse
 import base64
 from cryptography.fernet import Fernet
-from flask import request, jsonify
+
+try:
+    from flask import request, jsonify
+except ImportError:
+    request = None
+    jsonify = None
 
 CONFIG_DB = "/var/hifiberry/config.sqlite"
 KEY_FILE = "/etc/configdb.key"

--- a/configurator/handlers/player_registry_handler.py
+++ b/configurator/handlers/player_registry_handler.py
@@ -13,10 +13,11 @@ import logging
 from typing import Dict, Any, List
 
 try:
-    from flask import jsonify, make_response
+    from flask import jsonify, make_response, request
 except ImportError:
     jsonify = None
     make_response = None
+    request = None
 
 logger = logging.getLogger(__name__)
 
@@ -166,3 +167,37 @@ class PlayerRegistryHandler:
         except OSError as e:
             logger.error(f"Error reading icon {icon_path}: {e}")
             return jsonify({"status": "error", "message": "Failed to read icon"}), 500
+
+    def set_player_settings(self, systemd_service, values):
+        """Validate and persist setting values for one plugin.
+
+        Returns (applied_keys, errors)."""
+        descriptor = next(
+            (d for d in self._load_descriptors() if d["systemd_service"] == systemd_service),
+            None,
+        )
+        if descriptor is None:
+            return [], [f"unknown player service: {systemd_service}"]
+
+        allowed = {s["key"]: s for s in sanitize_settings(descriptor)}
+        applied, errors = [], []
+        for key, value in (values or {}).items():
+            setting = allowed.get(key)
+            if setting is None:
+                errors.append(f"unknown setting: {key}")
+                continue
+            self.configdb.set(
+                setting_value_key(systemd_service, key),
+                serialize_setting_value(setting["type"], value),
+            )
+            applied.append(key)
+        return applied, errors
+
+    def handle_set_player_settings(self, systemd_service):
+        """Flask handler: persist submitted player settings."""
+        values = request.get_json(silent=True) or {}
+        applied, errors = self.set_player_settings(systemd_service, values)
+        if not applied and errors:
+            return jsonify({"status": "error", "message": "; ".join(errors)}), 400
+        return jsonify({"status": "success",
+                        "data": {"applied": applied, "errors": errors}})

--- a/configurator/handlers/player_registry_handler.py
+++ b/configurator/handlers/player_registry_handler.py
@@ -28,6 +28,49 @@ SAFE_NAME_RE = re.compile(r'^[a-zA-Z0-9_-]+$')
 
 REQUIRED_FIELDS = ("name", "provided_by", "systemd_service", "icon")
 
+SETTING_TYPES = ("toggle", "select")
+_SETTING_REQUIRED = ("key", "type", "label", "default")
+
+
+def setting_value_key(systemd_service, key):
+    """ConfigDB key for a plugin setting value."""
+    return f"player.{systemd_service}.{key}"
+
+
+def coerce_setting_value(setting_type, raw):
+    """Coerce a stored TEXT value (or native value / None) to its typed form."""
+    if raw is None:
+        return None
+    if setting_type == "toggle":
+        if isinstance(raw, bool):
+            return raw
+        return str(raw).strip().lower() in ("true", "1", "yes", "on")
+    return str(raw)
+
+
+def serialize_setting_value(setting_type, value):
+    """Serialize a typed value to the TEXT form stored in ConfigDB."""
+    if setting_type == "toggle":
+        return "true" if value else "false"
+    return str(value)
+
+
+def sanitize_settings(descriptor):
+    """Return the descriptor's declared settings, dropping malformed entries."""
+    raw = descriptor.get("settings")
+    if not isinstance(raw, list):
+        return []
+    clean = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        if any(f not in entry for f in _SETTING_REQUIRED):
+            continue
+        if entry["type"] not in SETTING_TYPES:
+            continue
+        clean.append(entry)
+    return clean
+
 
 class PlayerRegistryHandler:
     """Handler for external player discovery and icon serving"""

--- a/configurator/handlers/player_registry_handler.py
+++ b/configurator/handlers/player_registry_handler.py
@@ -49,7 +49,11 @@ def coerce_setting_value(setting_type, raw):
 
 
 def serialize_setting_value(setting_type, value):
-    """Serialize a typed value to the TEXT form stored in ConfigDB."""
+    """Serialize a typed value to the TEXT form stored in ConfigDB.
+
+    For type == "toggle", expects value to already be a Python bool;
+    callers should coerce with coerce_setting_value first if needed.
+    """
     if setting_type == "toggle":
         return "true" if value else "false"
     return str(value)
@@ -68,6 +72,11 @@ def sanitize_settings(descriptor):
             continue
         if entry["type"] not in SETTING_TYPES:
             continue
+        # Drop select entries without a non-empty options list
+        if entry["type"] == "select":
+            options = entry.get("options")
+            if not isinstance(options, list) or len(options) == 0:
+                continue
         clean.append(entry)
     return clean
 

--- a/configurator/handlers/player_registry_handler.py
+++ b/configurator/handlers/player_registry_handler.py
@@ -179,16 +179,20 @@ class PlayerRegistryHandler:
         if descriptor is None:
             return [], [f"unknown player service: {systemd_service}"]
 
+        # Guard against non-dict bodies (list, string, number, etc.)
+        if not isinstance(values, dict):
+            return [], ["invalid request body"]
+
         allowed = {s["key"]: s for s in sanitize_settings(descriptor)}
         applied, errors = [], []
-        for key, value in (values or {}).items():
+        for key, value in values.items():
             setting = allowed.get(key)
             if setting is None:
                 errors.append(f"unknown setting: {key}")
                 continue
             self.configdb.set(
                 setting_value_key(systemd_service, key),
-                serialize_setting_value(setting["type"], value),
+                serialize_setting_value(setting["type"], coerce_setting_value(setting["type"], value)),
             )
             applied.append(key)
         return applied, errors

--- a/configurator/handlers/player_registry_handler.py
+++ b/configurator/handlers/player_registry_handler.py
@@ -84,52 +84,75 @@ def sanitize_settings(descriptor):
 class PlayerRegistryHandler:
     """Handler for external player discovery and icon serving"""
 
-    def handle_list_players(self):
-        """List all external players registered via drop-in descriptors."""
-        players: List[Dict[str, Any]] = []
+    def __init__(self, configdb=None, players_d_dir=PLAYERS_D_DIR):
+        self.configdb = configdb
+        self.players_d_dir = players_d_dir
+        self.icons_dir = os.path.join(players_d_dir, "icons")
 
-        if not os.path.isdir(PLAYERS_D_DIR):
-            return jsonify({"status": "success", "data": {"players": []}})
-
-        for filename in sorted(os.listdir(PLAYERS_D_DIR)):
+    def _load_descriptors(self):
+        """Load valid descriptor dicts from the players.d directory."""
+        descriptors = []
+        if not os.path.isdir(self.players_d_dir):
+            return descriptors
+        for filename in sorted(os.listdir(self.players_d_dir)):
             if not filename.endswith(".json"):
                 continue
-            path = os.path.join(PLAYERS_D_DIR, filename)
+            path = os.path.join(self.players_d_dir, filename)
             try:
                 with open(path, "r") as f:
                     descriptor = json.load(f)
             except (json.JSONDecodeError, OSError) as e:
                 logger.warning(f"Skipping invalid player descriptor {path}: {e}")
                 continue
-
             if not isinstance(descriptor, dict):
                 logger.warning(f"Skipping {path}: not a JSON object")
                 continue
-
             missing = [f for f in REQUIRED_FIELDS if f not in descriptor]
             if missing:
                 logger.warning(f"Skipping {path}: missing fields {missing}")
                 continue
+            descriptors.append(descriptor)
+        return descriptors
 
-            icon_name = descriptor["icon"]
+    def _settings_with_values(self, descriptor):
+        """Descriptor settings enriched with the current stored value."""
+        service = descriptor["systemd_service"]
+        out = []
+        for setting in sanitize_settings(descriptor):
+            value = None
+            if self.configdb is not None:
+                raw = self.configdb.get(setting_value_key(service, setting["key"]), default=None)
+                value = coerce_setting_value(setting["type"], raw)
+            if value is None:
+                value = setting["default"]
+            out.append({**setting, "value": value})
+        return out
+
+    def _build_players(self):
+        players = []
+        for descriptor in self._load_descriptors():
             players.append({
                 "name": descriptor["name"],
                 "provided_by": descriptor["provided_by"],
                 "systemd_service": descriptor["systemd_service"],
-                "icon_url": f"/api/v1/players/icon/{icon_name}",
+                "icon_url": f"/api/v1/players/icon/{descriptor['icon']}",
                 "allow_change": descriptor.get("allow_change", True),
                 "maintainer_name": descriptor.get("maintainer_name", ""),
                 "maintainer_url": descriptor.get("maintainer_url", ""),
+                "settings": self._settings_with_values(descriptor),
             })
+        return players
 
-        return jsonify({"status": "success", "data": {"players": players}})
+    def handle_list_players(self):
+        """List all external players registered via drop-in descriptors."""
+        return jsonify({"status": "success", "data": {"players": self._build_players()}})
 
     def handle_player_icon(self, name: str):
         """Serve an external player icon SVG."""
         if not SAFE_NAME_RE.match(name):
             return jsonify({"status": "error", "message": "Invalid icon name"}), 400
 
-        icon_path = os.path.join(ICONS_DIR, f"{name}.svg")
+        icon_path = os.path.join(self.icons_dir, f"{name}.svg")
         if not os.path.isfile(icon_path):
             return jsonify({"status": "error", "message": "Icon not found"}), 404
 

--- a/configurator/server.py
+++ b/configurator/server.py
@@ -72,7 +72,7 @@ class ConfigAPIServer:
         self.i2c_handler = I2CHandler()
         self.volume_handler = VolumeHandler()
         self.bluetooth_handler = BluetoothHandler()
-        self.player_registry_handler = PlayerRegistryHandler()
+        self.player_registry_handler = PlayerRegistryHandler(self.configdb)
         self.ble_handler = BLEProvisioningHandler()
             
         logger.info("ConfigAPIServer.__init__: Creating SettingsManager")

--- a/configurator/server.py
+++ b/configurator/server.py
@@ -520,6 +520,11 @@ class ConfigAPIServer:
             """Serve an external player icon SVG"""
             return self.player_registry_handler.handle_player_icon(name)
 
+        @self.app.route('/api/v1/players/<systemd_service>/settings', methods=['PUT', 'POST'])
+        def set_player_settings(systemd_service):
+            """Persist settings for an external player plugin"""
+            return self.player_registry_handler.handle_set_player_settings(systemd_service)
+
         # BLE provisioning endpoints
         @self.app.route('/api/v1/ble/provisioning/status', methods=['GET'])
         def get_ble_provisioning_status():

--- a/tests/test_player_registry_listing.py
+++ b/tests/test_player_registry_listing.py
@@ -1,0 +1,63 @@
+import json
+import os
+from configurator.handlers.player_registry_handler import PlayerRegistryHandler
+from configurator.configdb import ConfigDB
+
+
+def _write_descriptor(dir_path, filename, descriptor):
+    os.makedirs(dir_path, exist_ok=True)
+    with open(os.path.join(dir_path, filename), "w") as f:
+        json.dump(descriptor, f)
+
+
+def test_build_players_includes_settings_with_default_value(tmp_path):
+    players_d = tmp_path / "players.d"
+    _write_descriptor(str(players_d), "analog.json", {
+        "name": "Analog Input",
+        "provided_by": "analog-recognition",
+        "systemd_service": "analog-recognition",
+        "icon": "analog",
+        "settings": [
+            {"key": "songrec_enabled", "type": "toggle",
+             "label": "Recognize tracks", "default": True},
+        ],
+    })
+    configdb = ConfigDB(db_path=str(tmp_path / "config.sqlite"))
+    handler = PlayerRegistryHandler(configdb=configdb, players_d_dir=str(players_d))
+
+    players = handler._build_players()
+    assert len(players) == 1
+    settings = players[0]["settings"]
+    assert settings[0]["key"] == "songrec_enabled"
+    assert settings[0]["value"] is True  # falls back to default when unset
+
+
+def test_build_players_reads_stored_value(tmp_path):
+    players_d = tmp_path / "players.d"
+    _write_descriptor(str(players_d), "analog.json", {
+        "name": "Analog Input",
+        "provided_by": "analog-recognition",
+        "systemd_service": "analog-recognition",
+        "icon": "analog",
+        "settings": [
+            {"key": "songrec_enabled", "type": "toggle",
+             "label": "Recognize tracks", "default": True},
+        ],
+    })
+    configdb = ConfigDB(db_path=str(tmp_path / "config.sqlite"))
+    configdb.set("player.analog-recognition.songrec_enabled", "false")
+    handler = PlayerRegistryHandler(configdb=configdb, players_d_dir=str(players_d))
+
+    players = handler._build_players()
+    assert players[0]["settings"][0]["value"] is False
+
+
+def test_build_players_no_settings_key_yields_empty_list(tmp_path):
+    players_d = tmp_path / "players.d"
+    _write_descriptor(str(players_d), "lms.json", {
+        "name": "LMS", "provided_by": "squeezelite",
+        "systemd_service": "squeezelite", "icon": "squeezelite",
+    })
+    configdb = ConfigDB(db_path=str(tmp_path / "config.sqlite"))
+    handler = PlayerRegistryHandler(configdb=configdb, players_d_dir=str(players_d))
+    assert handler._build_players()[0]["settings"] == []

--- a/tests/test_player_settings_helpers.py
+++ b/tests/test_player_settings_helpers.py
@@ -1,0 +1,50 @@
+from configurator.handlers.player_registry_handler import (
+    setting_value_key,
+    coerce_setting_value,
+    serialize_setting_value,
+    sanitize_settings,
+)
+
+
+def test_setting_value_key_namespaces_by_service():
+    assert setting_value_key("analog-recognition", "songrec_enabled") == \
+        "player.analog-recognition.songrec_enabled"
+
+
+def test_coerce_toggle_from_stored_strings():
+    assert coerce_setting_value("toggle", "true") is True
+    assert coerce_setting_value("toggle", "false") is False
+    assert coerce_setting_value("toggle", "1") is True
+    assert coerce_setting_value("toggle", True) is True
+    assert coerce_setting_value("toggle", None) is None
+
+
+def test_coerce_select_returns_string_or_none():
+    assert coerce_setting_value("select", "medium") == "medium"
+    assert coerce_setting_value("select", None) is None
+
+
+def test_serialize_toggle_uses_true_false_strings():
+    assert serialize_setting_value("toggle", True) == "true"
+    assert serialize_setting_value("toggle", False) == "false"
+    assert serialize_setting_value("select", "high") == "high"
+
+
+def test_sanitize_settings_drops_invalid_and_keeps_valid():
+    descriptor = {
+        "settings": [
+            {"key": "songrec_enabled", "type": "toggle", "label": "Recognize", "default": True},
+            {"key": "bad_no_type", "label": "x", "default": 1},
+            {"key": "mode", "type": "select", "label": "Mode", "default": "a",
+             "options": [{"value": "a", "label": "A"}]},
+            {"key": "bad_type", "type": "slider", "label": "y", "default": 1},
+        ]
+    }
+    out = sanitize_settings(descriptor)
+    keys = [s["key"] for s in out]
+    assert keys == ["songrec_enabled", "mode"]
+    assert out[0]["type"] == "toggle"
+
+
+def test_sanitize_settings_absent_is_empty():
+    assert sanitize_settings({"name": "x"}) == []

--- a/tests/test_player_settings_helpers.py
+++ b/tests/test_player_settings_helpers.py
@@ -48,3 +48,51 @@ def test_sanitize_settings_drops_invalid_and_keeps_valid():
 
 def test_sanitize_settings_absent_is_empty():
     assert sanitize_settings({"name": "x"}) == []
+
+
+def test_sanitize_settings_drops_select_without_options():
+    """A select setting with no options key is dropped."""
+    descriptor = {
+        "settings": [
+            {"key": "mode", "type": "select", "label": "Mode", "default": "a"},
+        ]
+    }
+    out = sanitize_settings(descriptor)
+    assert out == []
+
+
+def test_sanitize_settings_keeps_select_with_options():
+    """A select setting with non-empty options list is kept."""
+    descriptor = {
+        "settings": [
+            {"key": "mode", "type": "select", "label": "Mode", "default": "a",
+             "options": [{"value": "a", "label": "A"}]},
+        ]
+    }
+    out = sanitize_settings(descriptor)
+    assert len(out) == 1
+    assert out[0]["key"] == "mode"
+
+
+def test_sanitize_settings_drops_select_with_empty_options():
+    """A select setting with empty options list is dropped."""
+    descriptor = {
+        "settings": [
+            {"key": "mode", "type": "select", "label": "Mode", "default": "a",
+             "options": []},
+        ]
+    }
+    out = sanitize_settings(descriptor)
+    assert out == []
+
+
+def test_sanitize_settings_toggle_ignores_options():
+    """Toggle settings are not affected by presence/absence of options."""
+    descriptor = {
+        "settings": [
+            {"key": "enabled", "type": "toggle", "label": "Enable", "default": True},
+        ]
+    }
+    out = sanitize_settings(descriptor)
+    assert len(out) == 1
+    assert out[0]["key"] == "enabled"

--- a/tests/test_player_settings_write.py
+++ b/tests/test_player_settings_write.py
@@ -43,3 +43,22 @@ def test_set_player_settings_unknown_service(tmp_path):
     applied, errors = handler.set_player_settings("does-not-exist", {"x": 1})
     assert applied == []
     assert errors
+
+
+def test_set_player_settings_non_dict_body_does_not_crash(tmp_path):
+    """Non-dict body (list, string, number) should return error without crashing."""
+    handler, _ = _setup(tmp_path)
+    applied, errors = handler.set_player_settings("analog-recognition", ["not", "a", "dict"])
+    assert applied == []
+    assert errors  # Should have at least one error
+    assert not any("Traceback" in e for e in errors)  # No exception message
+
+
+def test_set_player_settings_coerces_toggle_string_false(tmp_path):
+    """String 'false' for toggle setting should be coerced and stored as 'false'."""
+    handler, configdb = _setup(tmp_path)
+    applied, errors = handler.set_player_settings("analog-recognition", {"songrec_enabled": "false"})
+    assert applied == ["songrec_enabled"]
+    assert errors == []
+    # The string "false" should be coerced to bool False, then serialized back to "false"
+    assert configdb.get("player.analog-recognition.songrec_enabled") == "false"

--- a/tests/test_player_settings_write.py
+++ b/tests/test_player_settings_write.py
@@ -1,0 +1,45 @@
+import json
+import os
+from configurator.handlers.player_registry_handler import PlayerRegistryHandler
+from configurator.configdb import ConfigDB
+
+
+def _setup(tmp_path):
+    players_d = tmp_path / "players.d"
+    os.makedirs(str(players_d), exist_ok=True)
+    with open(os.path.join(str(players_d), "analog.json"), "w") as f:
+        json.dump({
+            "name": "Analog Input",
+            "provided_by": "analog-recognition",
+            "systemd_service": "analog-recognition",
+            "icon": "analog",
+            "settings": [
+                {"key": "songrec_enabled", "type": "toggle",
+                 "label": "Recognize tracks", "default": True},
+            ],
+        }, f)
+    configdb = ConfigDB(db_path=str(tmp_path / "config.sqlite"))
+    handler = PlayerRegistryHandler(configdb=configdb, players_d_dir=str(players_d))
+    return handler, configdb
+
+
+def test_set_player_settings_writes_namespaced_key(tmp_path):
+    handler, configdb = _setup(tmp_path)
+    applied, errors = handler.set_player_settings("analog-recognition", {"songrec_enabled": False})
+    assert applied == ["songrec_enabled"]
+    assert errors == []
+    assert configdb.get("player.analog-recognition.songrec_enabled") == "false"
+
+
+def test_set_player_settings_rejects_unknown_key(tmp_path):
+    handler, _ = _setup(tmp_path)
+    applied, errors = handler.set_player_settings("analog-recognition", {"nope": True})
+    assert applied == []
+    assert any("nope" in e for e in errors)
+
+
+def test_set_player_settings_unknown_service(tmp_path):
+    handler, _ = _setup(tmp_path)
+    applied, errors = handler.set_player_settings("does-not-exist", {"x": 1})
+    assert applied == []
+    assert errors


### PR DESCRIPTION
## What

Adds a generic **plugin-settings** capability to the external-player registry so a HiFiBerryOS player plugin can declare configurable settings that the web UI renders and persists — no per-plugin code. First consumer is `analog-recognition`'s "Recognize tracks" toggle (separate repo).

## Changes (`PlayerRegistryHandler` + `server.py`)

- **Pure helpers**: `setting_value_key` (`player.<systemd_service>.<key>`), `coerce_setting_value`, `serialize_setting_value` (booleans ↔ `"true"`/`"false"` TEXT), `sanitize_settings` (validates schema; drops malformed entries and `select` settings without `options`).
- `GET /api/v1/players` now includes each descriptor's `settings`, enriched with the current value read from ConfigDB (falling back to the declared `default`).
- New `PUT /api/v1/players/<systemd_service>/settings` — validates submitted values against the declared schema, coerces by type, and persists them namespaced in ConfigDB. Rejects unknown service / unknown keys / non-dict bodies.
- `PlayerRegistryHandler` is now ConfigDB-aware (`__init__(configdb, players_d_dir)`), with descriptor loading factored into `_load_descriptors`.

## Testing

First pytest suite for this repo (`tests/`): 18 tests covering the helpers, listing (defaults + stored values + empty), and the write endpoint (namespacing, unknown key/service rejection, non-dict guard, string-`"false"` coercion). `python3 -m pytest tests/ -v` → 18 passed.

Descriptors without a `settings` key are unaffected; existing players (mpd/raat/librespot/…) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
