### PR TITLE
soundcard: detect input-only ADC via arecord so --has-input works without EEPROM/pin

### DIFF
--- a/configurator/_version.py
+++ b/configurator/_version.py
@@ -4,7 +4,7 @@ Version information for HiFiBerry Configurator
 Single source of truth for version number
 """
 
-__version__ = "2.13.18"
+__version__ = "2.13.19"
 __version_info__ = tuple(map(int, __version__.split('.')))
 
 # For backward compatibility

--- a/configurator/soundcard.py
+++ b/configurator/soundcard.py
@@ -307,6 +307,7 @@ SOUND_CARD_DEFINITIONS = {
     },
     "ADC": {
         "aplay_contains": None,
+        "arecord_contains": "snd_rpi_hifiberry_adc",
         "hat_name": "ADC",
         "volume_control": None,
         "output_channels": 0,

--- a/configurator/soundcard_detector.py
+++ b/configurator/soundcard_detector.py
@@ -453,6 +453,25 @@ class SoundcardDetector:
         elif self.verbose:
             logging.info("aplay detection: FAILED - proceeding to next method")
 
+        # Try arecord detection for input-only cards (e.g. the ADC). These
+        # have no playback device, so they never appear in `aplay -l` and the
+        # step above cannot see them; match them against the capture-device
+        # list instead.
+        if self.verbose:
+            logging.info("Step 3b: Attempting arecord detection (input-only cards)...")
+        detected_overlay = self._detect_from_arecord()
+        if detected_overlay and self._validate_detected_card(detected_overlay):
+            self.detected_overlay = detected_overlay
+            self.detected_card = self._get_card_name(detected_overlay, hat_product=hat_card, no_hat_only=not has_hat_info)
+            self._log_hifiberry_event(f"Detected sound card: {self.detected_card} (via arecord)")
+            if self.verbose:
+                logging.info(f"arecord detection: SUCCESS - {self.detected_card} (overlay: {self.detected_overlay})")
+            self._canonicalize_card_name()
+            self._refine_card_by_dsp_program()
+            return  # Successfully detected and validated
+        elif self.verbose:
+            logging.info("arecord detection: FAILED - proceeding to next method")
+
         # If aplay detection failed, try DSP detection as final fallback
         if self.verbose:
             logging.info("Step 4: Attempting DSP detection...")
@@ -593,6 +612,35 @@ class SoundcardDetector:
             )
             self.detected_card = model_name
             return
+
+    def _detect_from_arecord(self):
+        """Detect an input-only HiFiBerry card (e.g. the ADC) from `arecord -l`.
+
+        Input-only cards have no playback device, so they never appear in
+        `aplay -l` and the aplay step cannot see them. Match each card's
+        ``arecord_contains`` marker against the capture-device list instead.
+
+        Returns the base overlay name (e.g. "adc", the same form
+        ``_map_aplay_to_overlay`` returns) or None if no input card matches.
+        """
+        from configurator.soundcard import SOUND_CARD_DEFINITIONS
+
+        output = self._run_command("arecord -l")
+        if not output:
+            return None
+        output_lower = output.lower()
+
+        for card_name, attributes in SOUND_CARD_DEFINITIONS.items():
+            marker = attributes.get("arecord_contains")
+            if not marker or marker.lower() not in output_lower:
+                continue
+            dtoverlay = attributes.get("dtoverlay", "")
+            if not dtoverlay:
+                continue
+            overlay = dtoverlay.replace("hifiberry-", "", 1).split(",")[0]
+            logging.info(f"Found HiFiBerry input card via arecord: {card_name} (marker '{marker}')")
+            return overlay
+        return None
 
     def _map_aplay_to_overlay(self, aplay_output):
         """

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+hifiberry-configurator (2.13.19) stable; urgency=medium
+
+  * soundcard: detect input-only cards (the HiFiBerry ADC) from `arecord -l`.
+    The ADC has no playback device, so it never appears in `aplay -l` and,
+    without a HAT EEPROM or a `# HiFiBerry card:` pin, detection fell through
+    to "Unknown" with 0 input channels — so `config-soundcard --has-input`
+    wrongly reported no input on ADC boards configured via a raw
+    `dtoverlay=hifiberry-adc`. Added an `arecord_contains` marker to the ADC
+    card definition and an arecord detection step (after aplay, before DSP)
+    that matches it, so the ADC is identified from its actual capture device.
+
+ -- HiFiBerry <info@hifiberry.com>  Mon, 06 Jul 2026 16:00:00 +0000
+
 hifiberry-configurator (2.13.18) stable; urgency=medium
 
   * soundcard: add `config-soundcard --has-input`, which exits 0 when the

--- a/tests/test_soundcard_arecord.py
+++ b/tests/test_soundcard_arecord.py
@@ -1,0 +1,44 @@
+from unittest.mock import patch
+
+from configurator.soundcard import SOUND_CARD_DEFINITIONS
+from configurator.soundcard_detector import SoundcardDetector
+
+
+ARECORD_ADC = """**** List of CAPTURE Hardware Devices ****
+card 2: sndrpihifiberry [snd_rpi_hifiberry_adc], device 0: HiFiBerry ADC HiFi pcm1863-aif-0 [HiFiBerry ADC HiFi pcm1863-aif-0]
+  Subdevices: 0/1
+  Subdevice #0: subdevice #0
+"""
+
+ARECORD_NO_HIFIBERRY = """**** List of CAPTURE Hardware Devices ****
+card 0: Generic [HD-Audio Generic], device 0: ALC generic [ALC generic]
+  Subdevices: 1/1
+"""
+
+
+def _detector(tmp_path):
+    cfg = tmp_path / "config.txt"
+    cfg.write_text("dtoverlay=hifiberry-adc\n")
+    return SoundcardDetector(config_file=str(cfg))
+
+
+def test_adc_entry_has_arecord_marker():
+    assert SOUND_CARD_DEFINITIONS["ADC"]["arecord_contains"] == "snd_rpi_hifiberry_adc"
+
+
+def test_detect_from_arecord_finds_adc(tmp_path):
+    det = _detector(tmp_path)
+    with patch.object(det, "_run_command", return_value=ARECORD_ADC):
+        assert det._detect_from_arecord() == "adc"
+
+
+def test_detect_from_arecord_none_when_no_hifiberry_input(tmp_path):
+    det = _detector(tmp_path)
+    with patch.object(det, "_run_command", return_value=ARECORD_NO_HIFIBERRY):
+        assert det._detect_from_arecord() is None
+
+
+def test_detect_from_arecord_none_when_no_capture_devices(tmp_path):
+    det = _detector(tmp_path)
+    with patch.object(det, "_run_command", return_value=""):
+        assert det._detect_from_arecord() is None


### PR DESCRIPTION
## Problem

On a HiFiBerry **ADC** board configured with a raw `dtoverlay=hifiberry-adc` (no HAT EEPROM, no `# HiFiBerry card:` pin), `config-soundcard --has-input` exits **1** ("no input") even though the ADC is present and captures fine (ALSA `snd_rpi_hifiberry_adc`, PCM1863). This makes the `analog-recognition` service's `ExecCondition=config-soundcard --has-input` skip the service on real vinyl/RIAA devices.

## Root cause

The ADC is **input-only** — it has no playback device, so it never appears in `aplay -l`, and the aplay detection step can't see it. With no EEPROM and no pin comment either, detection falls through to *Unknown* → `input_channels: 0` → `--has-input` = 1. (The `DAC+ ADC` variants are unaffected: they have a DAC and are found via `aplay`.)

## Fix

- Add an `arecord_contains: "snd_rpi_hifiberry_adc"` marker to the `ADC` card definition.
- Add an `arecord` detection step (after `aplay`, before `DSP`) that matches each card's `arecord_contains` against `arecord -l`, so input-only cards are identified from their actual capture device. Returns the base overlay (`adc`) exactly like the aplay path, so `_validate_detected_card` / `_get_card_name` handle it unchanged.

Now the ADC resolves to the `ADC` card (`input_channels: 2`) and `--has-input` exits 0.

## Tests

New `tests/test_soundcard_arecord.py` (4 cases): the ADC marker exists; arecord output identifies the ADC as overlay `adc`; non-HiFiBerry capture and empty output return `None`. Full suite: 22 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
