### PR TITLE
Add config-supportinfo

### DIFF
--- a/configurator/_version.py
+++ b/configurator/_version.py
@@ -4,7 +4,7 @@ Version information for HiFiBerry Configurator
 Single source of truth for version number
 """
 
-__version__ = "2.14.5"
+__version__ = "2.15.0"
 __version_info__ = tuple(map(int, __version__.split('.')))
 
 # For backward compatibility

--- a/configurator/supportinfo.py
+++ b/configurator/supportinfo.py
@@ -29,8 +29,15 @@ _URL_CREDENTIALS = re.compile(r"(?i)\b([a-z][a-z0-9+.\-]*://[^\s:/@]+):([^\s@]+)
 
 _BEARER_TOKEN = re.compile(r"(?i)\b(Authorization\s*:\s*Bearer\s+)([^\s,;\"']+)")
 
+# The body is consumed one full base64 line at a time (each line entirely
+# [A-Za-z0-9+/=], bounded by \n or end-of-string) rather than with a "any
+# character, lazily" match. That keeps consumption bounded to what an actual
+# PEM body can contain, so a block with no END marker stops at the first
+# line that is not base64 body instead of swallowing the rest of the report.
 _PEM_PRIVATE_KEY = re.compile(
-    r"(?is)(-----BEGIN [^\n-]*PRIVATE KEY-----)(.*?)(-----END [^\n-]*PRIVATE KEY-----|\Z)"
+    r"(?i)(-----BEGIN [^\n-]*PRIVATE KEY-----)"
+    r"(?:\n[A-Za-z0-9+/=]+(?=\n|\Z))*"
+    r"(\n-----END [^\n-]*PRIVATE KEY-----)?"
 )
 
 
@@ -42,11 +49,12 @@ def redact_secrets(text: str) -> str:
     credentials embedded in URLs (smb://user:pass@host), HTTP
     "Authorization: Bearer <token>" headers, and PEM private-key blocks
     (everything between a "-----BEGIN ... PRIVATE KEY-----" marker and its
-    matching "-----END" marker, or the end of the text if the block was
-    truncated, e.g. by a log excerpt that cuts off mid-key).
+    matching "-----END" marker, or, if the block was truncated, e.g. by a
+    log excerpt that cuts off mid-key, up to the last base64 body line --
+    unrelated content after a truncated block is left untouched).
     """
     text = _KEY_VALUE.sub(lambda m: f"{m.group(1)}{m.group(2)}{REDACTED}", text)
     text = _URL_CREDENTIALS.sub(lambda m: f"{m.group(1)}:{REDACTED}@", text)
     text = _BEARER_TOKEN.sub(lambda m: f"{m.group(1)}{REDACTED}", text)
-    text = _PEM_PRIVATE_KEY.sub(lambda m: f"{m.group(1)}{REDACTED}{m.group(3)}", text)
+    text = _PEM_PRIVATE_KEY.sub(lambda m: f"{m.group(1)}\n{REDACTED}{m.group(2) or ''}", text)
     return text

--- a/configurator/supportinfo.py
+++ b/configurator/supportinfo.py
@@ -5,9 +5,12 @@ The output of this tool is meant to be pasted into public GitHub issues, so
 everything it prints passes through redact_secrets() first.
 """
 
+import argparse
+import json
 import platform
 import re
 import subprocess
+import sys
 
 REDACTED = "***REDACTED***"
 
@@ -320,3 +323,78 @@ def collect_journal(lines: int = 40) -> str:
 def collect_disk() -> str:
     """Free space on the root filesystem."""
     return _run(["df", "-h", "/"])
+
+
+# --- Report assembly, redaction and CLI ---------------------------------
+
+
+def build_report(journal_lines: int = 40) -> dict:
+    """Collect every section of the diagnostic report."""
+    return {
+        "System": collect_system(),
+        "OS": collect_os(),
+        "Packages": collect_packages(),
+        "Services": collect_services(),
+        "Disk": collect_disk(),
+        "Recent errors": collect_journal(lines=journal_lines),
+    }
+
+
+def redact_report(report: dict) -> dict:
+    """Apply redaction to every string in the report, keeping its structure.
+
+    JSON is redacted here rather than after serialisation: running the value
+    patterns over rendered JSON would swallow the closing quote of a value like
+    "password=hunter2" and produce invalid JSON.
+    """
+    redacted = {}
+    for section, content in report.items():
+        if isinstance(content, dict):
+            redacted[section] = {
+                k: redact_secrets(str(v)) for k, v in content.items()
+            }
+        else:
+            redacted[section] = redact_secrets(str(content))
+    return redacted
+
+
+def render_text(report: dict) -> str:
+    """Render the report as a plain text block, ready to paste into an issue."""
+    parts = []
+    for section, content in report.items():
+        parts.append(f"## {section}")
+        if isinstance(content, dict):
+            for name, value in content.items():
+                parts.append(f"{name}: {value}")
+        else:
+            parts.append(str(content) if content else "(none)")
+        parts.append("")
+    return redact_secrets("\n".join(parts))
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="config-supportinfo",
+        description="Collect a redacted diagnostic report for HiFiBerryOS bug reports.",
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="output machine-readable JSON"
+    )
+    parser.add_argument(
+        "--journal-lines",
+        type=int,
+        default=40,
+        help="number of recent error lines to include (default: 40)",
+    )
+    args = parser.parse_args(argv)
+
+    report = build_report(journal_lines=args.journal_lines)
+    if args.json:
+        print(json.dumps(redact_report(report), indent=2))
+    else:
+        print(render_text(report))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/configurator/supportinfo.py
+++ b/configurator/supportinfo.py
@@ -9,24 +9,43 @@ import re
 
 REDACTED = "***REDACTED***"
 
+# Base secret words. The key-value pattern below wraps these in optional
+# leading/trailing identifier characters so it matches compound identifiers
+# that merely *contain* one of these words (WPA_PSK, AWS_SECRET_ACCESS_KEY,
+# secret_key, ...), not only identifiers equal to one of them. Over-matching
+# (e.g. redacting "secretary=x") is the accepted cost of that: a missed
+# secret is worse than an over-redacted harmless field.
 _SECRET_KEYS = (
-    r"password|passwd|psk|secret|client[_-]?secret|token|api[_-]?key|"
+    r"password|passwd|psk|passphrase|secret|token|api[_-]?key|"
     r"credential|credentials"
 )
 
 _KEY_VALUE = re.compile(
-    r"(?i)\b(" + _SECRET_KEYS + r")([\"']?\s*[:=]\s*)(\"[^\"]*\"|'[^']*'|[^\s,;\"']+)"
+    r"(?i)\b([A-Za-z0-9_.-]*(?:" + _SECRET_KEYS + r")[A-Za-z0-9_.-]*)"
+    r"([\"']?\s*[:=]\s*)(\"[^\"]*\"|'[^']*'|[^\s,;\"']+)"
 )
 
 _URL_CREDENTIALS = re.compile(r"(?i)\b([a-z][a-z0-9+.\-]*://[^\s:/@]+):([^\s@]+)@")
+
+_BEARER_TOKEN = re.compile(r"(?i)\b(Authorization\s*:\s*Bearer\s+)([^\s,;\"']+)")
+
+_PEM_PRIVATE_KEY = re.compile(
+    r"(?is)(-----BEGIN [^\n-]*PRIVATE KEY-----)(.*?)(-----END [^\n-]*PRIVATE KEY-----)"
+)
 
 
 def redact_secrets(text: str) -> str:
     """Replace secret values in text with REDACTED.
 
-    Handles two shapes: key/value pairs (password=..., psk: "...") and
-    credentials embedded in URLs (smb://user:pass@host).
+    Handles four shapes: key/value pairs (password=..., psk: "...", and
+    compound identifiers like WPA_PSK=... or AWS_SECRET_ACCESS_KEY=...),
+    credentials embedded in URLs (smb://user:pass@host), HTTP
+    "Authorization: Bearer <token>" headers, and PEM private-key blocks
+    (everything between a "-----BEGIN ... PRIVATE KEY-----" marker and its
+    matching "-----END" marker).
     """
     text = _KEY_VALUE.sub(lambda m: f"{m.group(1)}{m.group(2)}{REDACTED}", text)
     text = _URL_CREDENTIALS.sub(lambda m: f"{m.group(1)}:{REDACTED}@", text)
+    text = _BEARER_TOKEN.sub(lambda m: f"{m.group(1)}{REDACTED}", text)
+    text = _PEM_PRIVATE_KEY.sub(lambda m: f"{m.group(1)}{REDACTED}{m.group(3)}", text)
     return text

--- a/configurator/supportinfo.py
+++ b/configurator/supportinfo.py
@@ -5,6 +5,7 @@ The output of this tool is meant to be pasted into public GitHub issues, so
 everything it prints passes through redact_secrets() first.
 """
 
+import platform
 import re
 
 REDACTED = "***REDACTED***"
@@ -180,3 +181,47 @@ def redact_secrets(text: str) -> str:
     text = _BEARER_TOKEN.sub(lambda m: f"{m.group(1)}{REDACTED}", text)
     text = _redact_pem_keys(text)
     return text
+
+
+# --- Hardware and OS collectors -----------------------------------------
+#
+# UUID, Hostname and Pretty Hostname are dropped from the hardware report:
+# the UUID is a stable device identifier and hostnames regularly contain
+# people's real names, and this report is meant to be pasted into public
+# GitHub issues. Neither field helps debugging.
+
+OMITTED_SYSTEM_FIELDS = {"UUID", "Hostname", "Pretty Hostname"}
+
+
+def _flat_system_info() -> dict:
+    """Indirection so tests can replace the hardware-dependent lookup."""
+    from configurator.systeminfo import SystemInfo
+
+    return SystemInfo().get_flat_info_dict()
+
+
+def collect_system() -> dict:
+    """Hardware description, without fields that identify the device or owner."""
+    try:
+        info = _flat_system_info()
+    except Exception as e:
+        return {"error": f"could not read system info: {e}"}
+    return {k: v for k, v in info.items() if k not in OMITTED_SYSTEM_FIELDS}
+
+
+def collect_os() -> dict:
+    """Distribution, kernel and architecture."""
+    pretty_name = "unknown"
+    try:
+        with open("/etc/os-release") as f:
+            for line in f:
+                if line.startswith("PRETTY_NAME="):
+                    pretty_name = line.split("=", 1)[1].strip().strip('"')
+                    break
+    except OSError:
+        pass
+    return {
+        "OS": pretty_name,
+        "Kernel": platform.release(),
+        "Architecture": platform.machine(),
+    }

--- a/configurator/supportinfo.py
+++ b/configurator/supportinfo.py
@@ -185,12 +185,15 @@ def redact_secrets(text: str) -> str:
 
 # --- Hardware and OS collectors -----------------------------------------
 #
-# UUID, Hostname and Pretty Hostname are dropped from the hardware report:
-# the UUID is a stable device identifier and hostnames regularly contain
-# people's real names, and this report is meant to be pasted into public
-# GitHub issues. Neither field helps debugging.
+# Kept fields are selected by allowlist, not by excluding known-bad ones: a
+# denylist silently leaks the next identifying field that get_flat_info_dict()
+# grows (e.g. a MAC address or serial number) straight into a report that
+# gets pasted into public GitHub issues. UUID, Hostname and Pretty Hostname
+# are deliberately left off this allowlist -- the UUID is a stable device
+# identifier and hostnames regularly contain people's real names, and
+# neither helps debugging.
 
-OMITTED_SYSTEM_FIELDS = {"UUID", "Hostname", "Pretty Hostname"}
+SAFE_SYSTEM_FIELDS = {"Pi Model", "Memory", "HAT", "Sound Card"}
 
 
 def _flat_system_info() -> dict:
@@ -206,7 +209,7 @@ def collect_system() -> dict:
         info = _flat_system_info()
     except Exception as e:
         return {"error": f"could not read system info: {e}"}
-    return {k: v for k, v in info.items() if k not in OMITTED_SYSTEM_FIELDS}
+    return {k: v for k, v in info.items() if k in SAFE_SYSTEM_FIELDS}
 
 
 def collect_os() -> dict:

--- a/configurator/supportinfo.py
+++ b/configurator/supportinfo.py
@@ -45,10 +45,14 @@ _PEM_BEGIN = re.compile(r"(?i)-----BEGIN [^\n-]*PRIVATE KEY-----")
 _PEM_END = re.compile(r"(?i)-----END [^\n-]*PRIVATE KEY-----")
 
 # Leading noise on a line that cannot itself be key material: indentation
-# and/or a journalctl prefix. Demanding at least three whitespace-separated
-# fields before the colon keeps ordinary report lines ("Sound Card: DAC2
-# HD", "Uptime: 3 days") from being mistaken for prefixed lines.
-_LINE_PREFIX = re.compile(r"[ \t]*(?:(?:\S+[ \t]+){2,}\S*:[ \t]+)?")
+# and/or a log prefix. A prefix is simply "everything up to the last ': '",
+# with no assumption about how many fields it holds -- journalctl writes
+# anything from "sshd[123]: " to "Aug 07 10:00:01 host sshd[123]: "
+# depending on its output format and flags, and counting fields silently
+# missed the shorter ones. Base64 never contains a colon, so this can never
+# cut into key material; what it leaves is classified on its own merits
+# below.
+_LINE_PREFIX = re.compile(r"[ \t]*(?:.*:[ \t]+)?")
 
 # A PEM body line: base64 with padding only at the very end. Excluding "="
 # from the middle is what keeps "password=hunter2" from looking like key
@@ -72,20 +76,23 @@ def _redact_payload(line: str) -> str:
     return prefix + REDACTED if payload else line
 
 
-def _is_key_body(payload: str, seen_body: bool) -> bool:
-    """Does this payload still look like part of a PEM body?
+def _is_key_body(line: str, payload: str, seen_body: bool) -> bool:
+    """Does this line still look like part of a PEM body?
 
     Only consulted for a block with no END marker, where the body's extent
     has to be guessed. The guess errs towards stopping early for anything
     that does not look like key material, because the alternative is
     swallowing report content.
     """
+    # Searched in the whole line, not in the payload: a header's own colon
+    # is what _LINE_PREFIX strips off, and the header may itself be behind
+    # a log prefix.
+    if _PEM_HEADER.search(line):
+        return True
     if not payload:
         # The blank line separating encrypted-key headers from the body;
         # once the base64 body has started, a blank line ends the block.
         return not seen_body
-    if _PEM_HEADER.match(payload):
-        return True
     return _BASE64_LINE.fullmatch(payload) is not None
 
 
@@ -144,10 +151,10 @@ def _redact_pem_keys(text: str) -> str:
                 i += 1
                 break
             _, payload = _split_line(line)
-            if not terminated and not _is_key_body(payload, seen_body):
+            if not terminated and not _is_key_body(line, payload, seen_body):
                 break
             out.append(_redact_payload(line))
-            if payload and not _PEM_HEADER.match(payload):
+            if payload and not _PEM_HEADER.search(line):
                 seen_body = True
             i += 1
 

--- a/configurator/supportinfo.py
+++ b/configurator/supportinfo.py
@@ -30,7 +30,7 @@ _URL_CREDENTIALS = re.compile(r"(?i)\b([a-z][a-z0-9+.\-]*://[^\s:/@]+):([^\s@]+)
 _BEARER_TOKEN = re.compile(r"(?i)\b(Authorization\s*:\s*Bearer\s+)([^\s,;\"']+)")
 
 _PEM_PRIVATE_KEY = re.compile(
-    r"(?is)(-----BEGIN [^\n-]*PRIVATE KEY-----)(.*?)(-----END [^\n-]*PRIVATE KEY-----)"
+    r"(?is)(-----BEGIN [^\n-]*PRIVATE KEY-----)(.*?)(-----END [^\n-]*PRIVATE KEY-----|\Z)"
 )
 
 
@@ -42,7 +42,8 @@ def redact_secrets(text: str) -> str:
     credentials embedded in URLs (smb://user:pass@host), HTTP
     "Authorization: Bearer <token>" headers, and PEM private-key blocks
     (everything between a "-----BEGIN ... PRIVATE KEY-----" marker and its
-    matching "-----END" marker).
+    matching "-----END" marker, or the end of the text if the block was
+    truncated, e.g. by a log excerpt that cuts off mid-key).
     """
     text = _KEY_VALUE.sub(lambda m: f"{m.group(1)}{m.group(2)}{REDACTED}", text)
     text = _URL_CREDENTIALS.sub(lambda m: f"{m.group(1)}:{REDACTED}@", text)

--- a/configurator/supportinfo.py
+++ b/configurator/supportinfo.py
@@ -29,16 +29,129 @@ _URL_CREDENTIALS = re.compile(r"(?i)\b([a-z][a-z0-9+.\-]*://[^\s:/@]+):([^\s@]+)
 
 _BEARER_TOKEN = re.compile(r"(?i)\b(Authorization\s*:\s*Bearer\s+)([^\s,;\"']+)")
 
-# The body is consumed one full base64 line at a time (each line entirely
-# [A-Za-z0-9+/=], bounded by \n or end-of-string) rather than with a "any
-# character, lazily" match. That keeps consumption bounded to what an actual
-# PEM body can contain, so a block with no END marker stops at the first
-# line that is not base64 body instead of swallowing the rest of the report.
-_PEM_PRIVATE_KEY = re.compile(
-    r"(?i)(-----BEGIN [^\n-]*PRIVATE KEY-----)"
-    r"(?:\n[A-Za-z0-9+/=]+(?=\n|\Z))*"
-    r"(\n-----END [^\n-]*PRIVATE KEY-----)?"
-)
+# --- PEM private-key blocks --------------------------------------------
+#
+# These are not handled with a single regex over the whole text. A PEM block
+# reaches the report in several shapes -- plain, indented, or with a
+# journalctl prefix ("Aug 07 10:00:01 host sshd[123]: ") in front of every
+# line -- and the text may also contain a BEGIN marker whose END marker was
+# cut off by a truncated log excerpt. A single pattern either misses the
+# prefixed shapes or, with an open-ended body match, eats the rest of the
+# report. So the block is walked line by line instead (see
+# _redact_pem_keys), with one hard rule: every input line produces exactly
+# one output line. Key material is *replaced*, never deleted.
+
+_PEM_BEGIN = re.compile(r"(?i)-----BEGIN [^\n-]*PRIVATE KEY-----")
+_PEM_END = re.compile(r"(?i)-----END [^\n-]*PRIVATE KEY-----")
+
+# Leading noise on a line that cannot itself be key material: indentation
+# and/or a journalctl prefix. Demanding at least three whitespace-separated
+# fields before the colon keeps ordinary report lines ("Sound Card: DAC2
+# HD", "Uptime: 3 days") from being mistaken for prefixed lines.
+_LINE_PREFIX = re.compile(r"[ \t]*(?:(?:\S+[ \t]+){2,}\S*:[ \t]+)?")
+
+# A PEM body line: base64 with padding only at the very end. Excluding "="
+# from the middle is what keeps "password=hunter2" from looking like key
+# material when it follows an unterminated block.
+_BASE64_LINE = re.compile(r"[A-Za-z0-9+/]+={0,2}")
+
+# RFC 1421 headers of an encrypted key; they sit between the BEGIN marker
+# and the base64 body and must not be read as the end of the block.
+_PEM_HEADER = re.compile(r"(?i)(?:Proc-Type|DEK-Info):")
+
+
+def _split_line(line: str) -> tuple:
+    """Split a line into its non-secret prefix and the payload after it."""
+    cut = _LINE_PREFIX.match(line).end()
+    return line[:cut], line[cut:].strip()
+
+
+def _redact_payload(line: str) -> str:
+    """Keep the line's prefix, replace whatever follows it."""
+    prefix, payload = _split_line(line)
+    return prefix + REDACTED if payload else line
+
+
+def _is_key_body(payload: str, seen_body: bool) -> bool:
+    """Does this payload still look like part of a PEM body?
+
+    Only consulted for a block with no END marker, where the body's extent
+    has to be guessed. The guess errs towards stopping early for anything
+    that does not look like key material, because the alternative is
+    swallowing report content.
+    """
+    if not payload:
+        # The blank line separating encrypted-key headers from the body;
+        # once the base64 body has started, a blank line ends the block.
+        return not seen_body
+    if _PEM_HEADER.match(payload):
+        return True
+    return _BASE64_LINE.fullmatch(payload) is not None
+
+
+def _redact_pem_keys(text: str) -> str:
+    """Replace the body of every PEM private-key block in text.
+
+    A block that has an END marker somewhere after it is redacted up to
+    that marker, whatever its lines look like. A block without one is
+    redacted only as far as the lines still look like key material, so the
+    diagnostics that follow a truncated block survive.
+    """
+    if not _PEM_BEGIN.search(text):
+        return text
+
+    lines = text.split("\n")
+    count = len(lines)
+
+    # Index of the next line from i onwards holding a BEGIN / an END marker.
+    # A block counts as terminated only if its END marker comes before the
+    # next BEGIN marker -- otherwise that END belongs to a later block and
+    # this one is truncated.
+    next_begin = [None] * (count + 1)
+    next_end = [None] * (count + 1)
+    for i in range(count - 1, -1, -1):
+        next_begin[i] = i if _PEM_BEGIN.search(lines[i]) else next_begin[i + 1]
+        next_end[i] = i if _PEM_END.search(lines[i]) else next_end[i + 1]
+
+    out = []
+    i = 0
+    while i < count:
+        line = lines[i]
+        i += 1
+        begin = _PEM_BEGIN.search(line)
+        if begin is None:
+            out.append(line)
+            continue
+
+        # Everything before the BEGIN marker is a prefix and stays; anything
+        # after it on the same line is key material.
+        head, rest = line[: begin.end()], line[begin.end():]
+        end = _PEM_END.search(rest)
+        if end is not None:
+            # Whole block squeezed onto one line.
+            out.append(head + _redact_payload(rest[: end.start()]) + rest[end.start():])
+            continue
+        out.append(head + (REDACTED if rest.strip() else ""))
+
+        end_at, begin_at = next_end[i], next_begin[i]
+        terminated = end_at is not None and (begin_at is None or end_at < begin_at)
+        seen_body = False
+        while i < count:
+            line = lines[i]
+            end = _PEM_END.search(line)
+            if end is not None:
+                out.append(_redact_payload(line[: end.start()]) + line[end.start():])
+                i += 1
+                break
+            _, payload = _split_line(line)
+            if not terminated and not _is_key_body(payload, seen_body):
+                break
+            out.append(_redact_payload(line))
+            if payload and not _PEM_HEADER.match(payload):
+                seen_body = True
+            i += 1
+
+    return "\n".join(out)
 
 
 def redact_secrets(text: str) -> str:
@@ -48,13 +161,15 @@ def redact_secrets(text: str) -> str:
     compound identifiers like WPA_PSK=... or AWS_SECRET_ACCESS_KEY=...),
     credentials embedded in URLs (smb://user:pass@host), HTTP
     "Authorization: Bearer <token>" headers, and PEM private-key blocks
-    (everything between a "-----BEGIN ... PRIVATE KEY-----" marker and its
-    matching "-----END" marker, or, if the block was truncated, e.g. by a
-    log excerpt that cuts off mid-key, up to the last base64 body line --
-    unrelated content after a truncated block is left untouched).
+    (the body between a "-----BEGIN ... PRIVATE KEY-----" marker and its
+    matching "-----END" marker -- or, if the block was truncated, e.g. by a
+    log excerpt that cuts off mid-key, as far as the lines look like key
+    material). PEM blocks are recognised no matter what precedes them on
+    the line, so journalctl-prefixed and indented blocks are covered too;
+    content that follows a truncated block is left untouched.
     """
     text = _KEY_VALUE.sub(lambda m: f"{m.group(1)}{m.group(2)}{REDACTED}", text)
     text = _URL_CREDENTIALS.sub(lambda m: f"{m.group(1)}:{REDACTED}@", text)
     text = _BEARER_TOKEN.sub(lambda m: f"{m.group(1)}{REDACTED}", text)
-    text = _PEM_PRIVATE_KEY.sub(lambda m: f"{m.group(1)}\n{REDACTED}{m.group(2) or ''}", text)
+    text = _redact_pem_keys(text)
     return text

--- a/configurator/supportinfo.py
+++ b/configurator/supportinfo.py
@@ -7,6 +7,7 @@ everything it prints passes through redact_secrets() first.
 
 import argparse
 import json
+import logging
 import platform
 import re
 import subprocess
@@ -364,12 +365,44 @@ def render_text(report: dict) -> str:
     for section, content in report.items():
         parts.append(f"## {section}")
         if isinstance(content, dict):
-            for name, value in content.items():
-                parts.append(f"{name}: {value}")
+            if content:
+                for name, value in content.items():
+                    parts.append(f"{name}: {value}")
+            else:
+                parts.append("(none)")
         else:
             parts.append(str(content) if content else "(none)")
         parts.append("")
     return redact_secrets("\n".join(parts))
+
+
+def setup_logging(verbose=False):
+    """Configure logging for this command, mirroring systeminfo.setup_logging().
+
+    Every failure that matters is already surfaced inside the report body as
+    "(command failed: ...)", via the collectors' own return values -- so the
+    WARNING/ERROR log lines the collectors (SystemInfo, hostname_utils, ...)
+    emit along the way are redundant with what the user is about to paste
+    into an issue, and would otherwise interleave with the report on a
+    terminal. Unlike systeminfo, which defaults to WARNING, this command
+    defaults above ERROR so that noise is suppressed by default; --verbose
+    restores full logging for local debugging.
+    """
+    log_level = logging.DEBUG if verbose else logging.CRITICAL
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(log_level)
+
+    for handler in root_logger.handlers[:]:
+        root_logger.removeHandler(handler)
+
+    console_handler = logging.StreamHandler(stream=sys.stderr)
+    console_handler.setLevel(log_level)
+
+    formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    console_handler.setFormatter(formatter)
+
+    root_logger.addHandler(console_handler)
 
 
 def main(argv=None) -> int:
@@ -386,7 +419,15 @@ def main(argv=None) -> int:
         default=40,
         help="number of recent error lines to include (default: 40)",
     )
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help="enable verbose logging"
+    )
     args = parser.parse_args(argv)
+
+    # Only main() configures logging: this module is also imported by
+    # config-server and other tools, and setting the root logger's level at
+    # import time would hijack their logging too.
+    setup_logging(args.verbose)
 
     report = build_report(journal_lines=args.journal_lines)
     if args.json:

--- a/configurator/supportinfo.py
+++ b/configurator/supportinfo.py
@@ -1,0 +1,32 @@
+"""
+config-supportinfo - collect a redacted diagnostic report for bug reports.
+
+The output of this tool is meant to be pasted into public GitHub issues, so
+everything it prints passes through redact_secrets() first.
+"""
+
+import re
+
+REDACTED = "***REDACTED***"
+
+_SECRET_KEYS = (
+    r"password|passwd|psk|secret|client[_-]?secret|token|api[_-]?key|"
+    r"credential|credentials"
+)
+
+_KEY_VALUE = re.compile(
+    r"(?i)\b(" + _SECRET_KEYS + r")([\"']?\s*[:=]\s*)(\"[^\"]*\"|'[^']*'|[^\s,;\"']+)"
+)
+
+_URL_CREDENTIALS = re.compile(r"(?i)\b([a-z][a-z0-9+.\-]*://[^\s:/@]+):([^\s@]+)@")
+
+
+def redact_secrets(text: str) -> str:
+    """Replace secret values in text with REDACTED.
+
+    Handles two shapes: key/value pairs (password=..., psk: "...") and
+    credentials embedded in URLs (smb://user:pass@host).
+    """
+    text = _KEY_VALUE.sub(lambda m: f"{m.group(1)}{m.group(2)}{REDACTED}", text)
+    text = _URL_CREDENTIALS.sub(lambda m: f"{m.group(1)}:{REDACTED}@", text)
+    return text

--- a/configurator/supportinfo.py
+++ b/configurator/supportinfo.py
@@ -7,6 +7,7 @@ everything it prints passes through redact_secrets() first.
 
 import platform
 import re
+import subprocess
 
 REDACTED = "***REDACTED***"
 
@@ -228,3 +229,75 @@ def collect_os() -> dict:
         "Kernel": platform.release(),
         "Architecture": platform.machine(),
     }
+
+
+# --- Commands that shell out -------------------------------------------
+
+PACKAGE_PATTERNS = [
+    "hifiberry-*",
+    "hbos-*",
+    "audiocontrol*",
+    "pipewire",
+    "mpd",
+    "librespot",
+    "shairport-sync",
+    "squeezelite",
+    "raat",
+    "roonbridge",
+]
+
+SERVICE_PATTERNS = [
+    "hifiberry*",
+    "audiocontrol*",
+    "config-server*",
+    "pipewire*",
+    "mpd*",
+    "librespot*",
+    "shairport*",
+    "squeezelite*",
+    "raat*",
+]
+
+
+def _run(cmd: list, timeout: int = 10) -> str:
+    """Run a command and return its stdout, or a note about why it failed."""
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout, check=False
+        )
+    except (OSError, subprocess.SubprocessError) as e:
+        return f"(command failed: {e})"
+    return result.stdout.strip()
+
+
+def collect_packages() -> str:
+    """Installed versions of the HiFiBerry and player packages.
+
+    dpkg-query exits non-zero for patterns that match nothing, which is normal
+    here -- most systems have only a few players installed. check=False in
+    _run keeps the matches we did get.
+    """
+    return _run(
+        ["dpkg-query", "-W", "-f=${Package} ${Version}\n"] + PACKAGE_PATTERNS
+    )
+
+
+def collect_services() -> str:
+    """State of the audio-related systemd units."""
+    return _run(
+        ["systemctl", "list-units", "--all", "--no-legend", "--no-pager"]
+        + SERVICE_PATTERNS
+    )
+
+
+def collect_journal(lines: int = 40) -> str:
+    """The most recent errors from the current boot."""
+    return _run(
+        ["journalctl", "-b", "-p", "err", "--no-pager", "-n", str(lines)],
+        timeout=20,
+    )
+
+
+def collect_disk() -> str:
+    """Free space on the root filesystem."""
+    return _run(["df", "-h", "/"])

--- a/configurator/supportinfo.py
+++ b/configurator/supportinfo.py
@@ -236,19 +236,16 @@ def collect_os() -> dict:
 PACKAGE_PATTERNS = [
     "hifiberry-*",
     "hbos-*",
-    "audiocontrol*",
     "pipewire",
     "mpd",
     "librespot",
     "shairport-sync",
     "squeezelite",
     "raat",
-    "roonbridge",
 ]
 
 SERVICE_PATTERNS = [
     "hifiberry*",
-    "audiocontrol*",
     "config-server*",
     "pipewire*",
     "mpd*",
@@ -256,18 +253,40 @@ SERVICE_PATTERNS = [
     "shairport*",
     "squeezelite*",
     "raat*",
+    "nqptp*",
+    "sigmatcpserver*",
+    "roomeq*",
+    "aes67*",
+    "usbaudio*",
+    "sendspin*",
+    "analoginput*",
+    "acr-webmcp*",
+    "nowplaying-sdl*",
+    "sambamount*",
 ]
 
 
 def _run(cmd: list, timeout: int = 10) -> str:
-    """Run a command and return its stdout, or a note about why it failed."""
+    """Run a command and return its stdout, or a note about why it failed.
+
+    stdout wins whenever there is any -- that is the dpkg-query case, which
+    routinely exits non-zero while still printing the matches it found. Only
+    when a non-zero exit left stdout empty is stderr surfaced instead, so a
+    permission error (e.g. journalctl run without the adm/systemd-journal
+    group) shows up as a reason rather than a silent blank section.
+    """
     try:
         result = subprocess.run(
             cmd, capture_output=True, text=True, timeout=timeout, check=False
         )
     except (OSError, subprocess.SubprocessError) as e:
         return f"(command failed: {e})"
-    return result.stdout.strip()
+    stdout = result.stdout.strip()
+    if stdout:
+        return stdout
+    if result.returncode != 0 and result.stderr.strip():
+        return f"(command failed: {result.stderr.strip()})"
+    return stdout
 
 
 def collect_packages() -> str:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,12 +1,17 @@
 hifiberry-configurator (2.15.0) stable; urgency=medium
 
-  * Player settings: add a 'number' type with min/max/step and range
-    validation, and allow select options to be sourced from a plugin's
-    own API via options_url (loopback hosts only).
   * Add config-supportinfo, which collects a redacted diagnostic report
     for bug reports on GitHub.
 
  -- HiFiBerry <support@hifiberry.com>  Fri, 07 Aug 2026 12:00:00 +0200
+
+hifiberry-configurator (2.14.6) stable; urgency=medium
+
+  * Player settings: add a 'number' type with min/max/step and range
+    validation, and allow select options to be sourced from a plugin's
+    own API via options_url (loopback hosts only).
+
+ -- HiFiBerry <support@hifiberry.com>  Thu, 06 Aug 2026 14:30:00 +0200
 
 hifiberry-configurator (2.14.5) stable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,12 @@
-hifiberry-configurator (2.14.6) stable; urgency=medium
+hifiberry-configurator (2.15.0) stable; urgency=medium
 
   * Player settings: add a 'number' type with min/max/step and range
     validation, and allow select options to be sourced from a plugin's
     own API via options_url (loopback hosts only).
+  * Add config-supportinfo, which collects a redacted diagnostic report
+    for bug reports on GitHub.
 
- -- HiFiBerry <support@hifiberry.com>  Thu, 06 Aug 2026 14:30:00 +0200
+ -- HiFiBerry <support@hifiberry.com>  Fri, 07 Aug 2026 12:00:00 +0200
 
 hifiberry-configurator (2.14.5) stable; urgency=medium
 

--- a/man/config-supportinfo.1
+++ b/man/config-supportinfo.1
@@ -1,0 +1,36 @@
+.TH CONFIG-SUPPORTINFO 1 "August 2026" "configurator 2.15.0" "HiFiBerry Configuration Tools"
+.SH NAME
+config-supportinfo \- collect a diagnostic report for bug reports
+.SH SYNOPSIS
+.B config-supportinfo
+[\fIOPTION\fR]
+.SH DESCRIPTION
+.B config-supportinfo
+collects hardware, package, service and error information into a single block
+of text that can be pasted into a bug report on
+https://github.com/hifiberry/hifiberry-os/issues.
+.PP
+Passwords, pre-shared keys, tokens and credentials embedded in URLs are
+replaced before anything is printed. Device UUID and hostnames are not
+included. Review the output before posting it anyway.
+.SH OPTIONS
+.TP
+.B \-\-json
+Output machine-readable JSON instead of text
+.TP
+.B \-\-journal\-lines \fIN\fR
+Number of recent error lines to include (default: 40)
+.TP
+.B \-v, \-\-verbose
+Enable verbose logging
+.SH EXIT STATUS
+.TP
+.B 0
+Report written to standard output
+.SH SEE ALSO
+.BR config-detect (1),
+.BR config-detectpi (1)
+.SH AUTHORS
+HiFiBerry Support <support@hifiberry.com>
+.SH COPYRIGHT
+Copyright (c) 2026 HiFiBerry. Licensed under the MIT License.

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,8 @@ setup(
             'man/config-volume.1',
             'man/config-wifi.1',
             'man/config-server.1',
-            'man/config-pipewire.1'
+            'man/config-pipewire.1',
+            'man/config-supportinfo.1'
         ]),
         ('/usr/share/man/man7', [
             'man/hifiberry-configurator.7',
@@ -81,6 +82,7 @@ setup(
             "config-server=configurator.server:main",
             "config-pipewire=configurator.pipewire:main",
             "config-ble-provision=configurator.ble_provisioning:main",
+            "config-supportinfo=configurator.supportinfo:main",
         ],
     },
     classifiers=[

--- a/tests/test_supportinfo_collect.py
+++ b/tests/test_supportinfo_collect.py
@@ -38,6 +38,17 @@ def test_collect_system_survives_a_broken_systeminfo():
     assert result == {"error": "could not read system info: boom"}
 
 
+def test_collect_system_drops_unexpected_new_fields():
+    info_with_new_fields = dict(
+        FLAT_INFO,
+        **{"Serial Number": "1000000012345678", "MAC Address": "dc:a6:32:00:00:00"},
+    )
+    with patch.object(supportinfo, "_flat_system_info", return_value=info_with_new_fields):
+        result = supportinfo.collect_system()
+    assert "Serial Number" not in result
+    assert "MAC Address" not in result
+
+
 def test_collect_os_reads_pretty_name():
     os_release = 'PRETTY_NAME="Debian GNU/Linux 13 (trixie)"\nID=debian\n'
     with patch("builtins.open", create=True) as mock_open:

--- a/tests/test_supportinfo_collect.py
+++ b/tests/test_supportinfo_collect.py
@@ -1,0 +1,50 @@
+# tests/test_supportinfo_collect.py
+from unittest.mock import patch
+
+from configurator import supportinfo
+
+
+FLAT_INFO = {
+    "Pi Model": "Raspberry Pi 5 Model B Rev 1.0 5",
+    "Memory": "8 GB (8192 MB)",
+    "HAT": "HiFiBerry DAC2 HD",
+    "Sound Card": "DAC2 HD",
+    "UUID": "deadbeef-0000-1111-2222-333344445555",
+    "Hostname": "daniels-wohnzimmer",
+    "Pretty Hostname": "Daniel's Living Room",
+}
+
+
+def test_collect_system_keeps_hardware_fields():
+    with patch.object(supportinfo, "_flat_system_info", return_value=dict(FLAT_INFO)):
+        result = supportinfo.collect_system()
+    assert result["Pi Model"] == "Raspberry Pi 5 Model B Rev 1.0 5"
+    assert result["HAT"] == "HiFiBerry DAC2 HD"
+    assert result["Sound Card"] == "DAC2 HD"
+    assert result["Memory"] == "8 GB (8192 MB)"
+
+
+def test_collect_system_drops_identifying_fields():
+    with patch.object(supportinfo, "_flat_system_info", return_value=dict(FLAT_INFO)):
+        result = supportinfo.collect_system()
+    assert "UUID" not in result
+    assert "Hostname" not in result
+    assert "Pretty Hostname" not in result
+
+
+def test_collect_system_survives_a_broken_systeminfo():
+    with patch.object(supportinfo, "_flat_system_info", side_effect=RuntimeError("boom")):
+        result = supportinfo.collect_system()
+    assert result == {"error": "could not read system info: boom"}
+
+
+def test_collect_os_reads_pretty_name():
+    os_release = 'PRETTY_NAME="Debian GNU/Linux 13 (trixie)"\nID=debian\n'
+    with patch("builtins.open", create=True) as mock_open:
+        mock_open.return_value.__enter__.return_value = os_release.splitlines(True)
+        with patch("platform.release", return_value="6.12.0-rpi"), \
+             patch("platform.machine", return_value="aarch64"):
+            result = supportinfo.collect_os()
+    assert result["OS"] == "Debian GNU/Linux 13 (trixie)"
+    assert result["Kernel"] == "6.12.0-rpi"
+    assert result["Architecture"] == "aarch64"

--- a/tests/test_supportinfo_commands.py
+++ b/tests/test_supportinfo_commands.py
@@ -8,6 +8,12 @@ def _completed(stdout):
     return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
 
 
+def _failed(stderr, stdout=""):
+    return subprocess.CompletedProcess(
+        args=[], returncode=1, stdout=stdout, stderr=stderr
+    )
+
+
 def test_run_returns_stripped_stdout():
     with patch("subprocess.run", return_value=_completed("hello\n")):
         assert supportinfo._run(["true"]) == "hello"
@@ -23,6 +29,22 @@ def test_run_reports_missing_binary_instead_of_raising():
 def test_run_reports_timeout():
     with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="x", timeout=10)):
         assert supportinfo._run(["x"]).startswith("(command failed:")
+
+
+def test_run_surfaces_stderr_when_stdout_is_empty_and_exit_is_nonzero():
+    stderr = "Failed to determine journal file ownership: Permission denied"
+    with patch("subprocess.run", return_value=_failed(stderr)):
+        result = supportinfo._run(["journalctl"])
+    assert result.startswith("(command failed:")
+    assert stderr in result
+
+
+def test_run_prefers_stdout_over_stderr_when_both_present():
+    with patch(
+        "subprocess.run",
+        return_value=_failed("some warning on stderr", stdout="hifiberry-mpd 1.2.3\n"),
+    ):
+        assert supportinfo._run(["dpkg-query"]) == "hifiberry-mpd 1.2.3"
 
 
 def test_collect_packages_asks_dpkg_for_the_known_patterns():
@@ -50,3 +72,24 @@ def test_collect_services_lists_audio_units():
     assert "mpd.service" in result
     cmd = run.call_args[0][0]
     assert cmd[0] == "systemctl"
+
+
+def test_package_patterns_drop_names_that_match_nothing_in_the_project():
+    assert "audiocontrol*" not in supportinfo.PACKAGE_PATTERNS
+    assert "roonbridge" not in supportinfo.PACKAGE_PATTERNS
+
+
+def test_service_patterns_cover_the_units_missing_from_the_original_list():
+    for pattern in (
+        "nqptp*",
+        "sigmatcpserver*",
+        "roomeq*",
+        "aes67*",
+        "usbaudio*",
+        "sendspin*",
+        "analoginput*",
+        "acr-webmcp*",
+        "nowplaying-sdl*",
+        "sambamount*",
+    ):
+        assert pattern in supportinfo.SERVICE_PATTERNS

--- a/tests/test_supportinfo_commands.py
+++ b/tests/test_supportinfo_commands.py
@@ -1,0 +1,52 @@
+import subprocess
+from unittest.mock import patch
+
+from configurator import supportinfo
+
+
+def _completed(stdout):
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+def test_run_returns_stripped_stdout():
+    with patch("subprocess.run", return_value=_completed("hello\n")):
+        assert supportinfo._run(["true"]) == "hello"
+
+
+def test_run_reports_missing_binary_instead_of_raising():
+    with patch("subprocess.run", side_effect=FileNotFoundError("no journalctl")):
+        result = supportinfo._run(["journalctl"])
+    assert result.startswith("(command failed:")
+    assert "no journalctl" in result
+
+
+def test_run_reports_timeout():
+    with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="x", timeout=10)):
+        assert supportinfo._run(["x"]).startswith("(command failed:")
+
+
+def test_collect_packages_asks_dpkg_for_the_known_patterns():
+    with patch("subprocess.run", return_value=_completed("hifiberry-configurator 2.15.0\n")) as run:
+        result = supportinfo.collect_packages()
+    assert result == "hifiberry-configurator 2.15.0"
+    cmd = run.call_args[0][0]
+    assert cmd[0] == "dpkg-query"
+    assert "hifiberry-*" in cmd
+    assert "mpd" in cmd
+
+
+def test_collect_journal_passes_the_line_limit():
+    with patch("subprocess.run", return_value=_completed("some error")) as run:
+        supportinfo.collect_journal(lines=5)
+    cmd = run.call_args[0][0]
+    assert cmd[0] == "journalctl"
+    assert "-n" in cmd and "5" in cmd
+    assert "-p" in cmd and "err" in cmd
+
+
+def test_collect_services_lists_audio_units():
+    with patch("subprocess.run", return_value=_completed("mpd.service loaded active running")) as run:
+        result = supportinfo.collect_services()
+    assert "mpd.service" in result
+    cmd = run.call_args[0][0]
+    assert cmd[0] == "systemctl"

--- a/tests/test_supportinfo_redaction.py
+++ b/tests/test_supportinfo_redaction.py
@@ -74,3 +74,17 @@ def test_pem_private_key_block_is_removed():
     assert "-----BEGIN RSA PRIVATE KEY-----" in result
     assert "-----END RSA PRIVATE KEY-----" in result
     assert REDACTED in result
+
+
+def test_truncated_pem_private_key_block_is_removed():
+    # Round 2: a log excerpt (e.g. journalctl -n 40) can cut off mid-key,
+    # so there is a BEGIN marker and key material but no END marker
+    # anywhere in the text. The key material must still not survive.
+    block = (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "MIIEpAIBAAKCAQEA1234567890abcdefghijklmnopqrstuvwxyz"
+    )
+    result = redact_secrets(block)
+    assert "MIIEpAIBAAKCAQEA1234567890abcdefghijklmnopqrstuvwxyz" not in result
+    assert "-----BEGIN RSA PRIVATE KEY-----" in result
+    assert REDACTED in result

--- a/tests/test_supportinfo_redaction.py
+++ b/tests/test_supportinfo_redaction.py
@@ -1,0 +1,32 @@
+from configurator.supportinfo import REDACTED, redact_secrets
+
+
+def test_key_value_secrets_are_removed():
+    assert redact_secrets("password=hunter2") == f"password={REDACTED}"
+    assert redact_secrets("psk = topsecret") == f"psk = {REDACTED}"
+    assert redact_secrets('client_secret: "abc123"') == f'client_secret: {REDACTED}'
+    assert redact_secrets("api-key=xyz") == f"api-key={REDACTED}"
+
+
+def test_case_is_ignored():
+    assert redact_secrets("PASSWORD=hunter2") == f"PASSWORD={REDACTED}"
+
+
+def test_credentials_in_urls_are_removed():
+    assert redact_secrets("smb://joe:hunter2@nas/music") == f"smb://joe:{REDACTED}@nas/music"
+
+
+def test_secrets_inside_longer_lines_are_removed():
+    line = "Aug 07 10:00:01 host mount[123]: mounting with username=joe,password=hunter2,vers=3.0"
+    result = redact_secrets(line)
+    assert "hunter2" not in result
+    assert "vers=3.0" in result
+
+
+def test_harmless_text_is_untouched():
+    text = "Sound Card: DAC2 HD\nPi Model: Raspberry Pi 5 Model B Rev 1.0 5"
+    assert redact_secrets(text) == text
+
+
+def test_token_word_alone_is_not_mangled():
+    assert redact_secrets("no tokens were found") == "no tokens were found"

--- a/tests/test_supportinfo_redaction.py
+++ b/tests/test_supportinfo_redaction.py
@@ -88,3 +88,21 @@ def test_truncated_pem_private_key_block_is_removed():
     assert "MIIEpAIBAAKCAQEA1234567890abcdefghijklmnopqrstuvwxyz" not in result
     assert "-----BEGIN RSA PRIVATE KEY-----" in result
     assert REDACTED in result
+
+
+def test_truncated_pem_block_does_not_swallow_trailing_report_content():
+    # Round 3: redact_secrets() runs over the whole collected report, not
+    # per line. An unterminated PEM block must not consume everything that
+    # follows it -- only the base64 key material.
+    report = (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "MIIEpAIBAAKCAQEA1234567890abcdefghijklmnopqrstuvwxyz\n"
+        "Sound Card: DAC2 HD\n"
+        "Kernel: 6.6.31\n"
+        "Uptime: 3 days"
+    )
+    result = redact_secrets(report)
+    assert "MIIEpAIBAAKCAQEA1234567890abcdefghijklmnopqrstuvwxyz" not in result
+    assert "Sound Card: DAC2 HD" in result
+    assert "Kernel: 6.6.31" in result
+    assert "Uptime: 3 days" in result

--- a/tests/test_supportinfo_redaction.py
+++ b/tests/test_supportinfo_redaction.py
@@ -30,3 +30,47 @@ def test_harmless_text_is_untouched():
 
 def test_token_word_alone_is_not_mangled():
     assert redact_secrets("no tokens were found") == "no tokens were found"
+
+
+def test_compound_psk_identifier_is_removed():
+    # Finding 1: \b does not fire between "_" and "p", so WPA_PSK / WLAN_PSK
+    # were previously left unredacted.
+    assert redact_secrets("WPA_PSK=abcdef1234567890") == f"WPA_PSK={REDACTED}"
+    assert redact_secrets("WLAN_PSK=abcdef1234567890") == f"WLAN_PSK={REDACTED}"
+
+
+def test_wpa_passphrase_is_removed():
+    # Finding 2: "passphrase" was missing from the word list entirely, so
+    # hostapd.conf's actual key (wpa_passphrase) was never redacted.
+    assert redact_secrets("wpa_passphrase=hunter2") == f"wpa_passphrase={REDACTED}"
+
+
+def test_compound_secret_key_identifiers_are_removed():
+    # Finding 3: compound keys where the operator does not immediately
+    # follow one of the listed words.
+    assert redact_secrets("secret_key=abc123") == f"secret_key={REDACTED}"
+    assert (
+        redact_secrets("AWS_SECRET_ACCESS_KEY=abc123")
+        == f"AWS_SECRET_ACCESS_KEY={REDACTED}"
+    )
+
+
+def test_bearer_token_is_removed():
+    # Finding 3: "Authorization: Bearer <token>" headers.
+    header = "Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.payload.signature"
+    assert redact_secrets(header) == f"Authorization: Bearer {REDACTED}"
+
+
+def test_pem_private_key_block_is_removed():
+    # Finding 3: PEM private-key blocks, everything between the BEGIN and
+    # the matching END marker.
+    block = (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "MIIEpAIBAAKCAQEA1234567890abcdefghijklmnopqrstuvwxyz\n"
+        "-----END RSA PRIVATE KEY-----"
+    )
+    result = redact_secrets(block)
+    assert "MIIEpAIBAAKCAQEA1234567890abcdefghijklmnopqrstuvwxyz" not in result
+    assert "-----BEGIN RSA PRIVATE KEY-----" in result
+    assert "-----END RSA PRIVATE KEY-----" in result
+    assert REDACTED in result

--- a/tests/test_supportinfo_redaction.py
+++ b/tests/test_supportinfo_redaction.py
@@ -106,3 +106,163 @@ def test_truncated_pem_block_does_not_swallow_trailing_report_content():
     assert "Sound Card: DAC2 HD" in result
     assert "Kernel: 6.6.31" in result
     assert "Uptime: 3 days" in result
+
+
+# --- Round 4: the PEM matrix -------------------------------------------
+# redact_secrets() sees the whole assembled report, which mixes plain
+# config dumps with journalctl output ("<time> <host> <unit>[pid]: " in
+# front of every line).  A PEM block therefore turns up in several shapes,
+# and all of them have to lose their key material without any diagnostic
+# line being deleted.
+
+
+def test_complete_pem_block_keeps_markers_and_replaces_body():
+    # (a) plain block, no prefixes: BEGIN/END stay, every body line is
+    # replaced one-for-one.
+    block = (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "MIIEpAIBAAKCAQEA1234567890abcdefghijklmnopqrstuvwxyz\n"
+        "AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHHIIIIJJJJKKKKLLLLMMMM\n"
+        "-----END RSA PRIVATE KEY-----"
+    )
+    assert redact_secrets(block) == (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        f"{REDACTED}\n"
+        f"{REDACTED}\n"
+        "-----END RSA PRIVATE KEY-----"
+    )
+
+
+def test_pem_block_with_journal_prefixes_is_redacted():
+    # (b) every line carries a journalctl prefix, so the block is not
+    # anchored to the start of the line.
+    prefix = "Aug 07 10:00:01 host sshd[123]: "
+    report = "\n".join(
+        [
+            prefix + "-----BEGIN OPENSSH PRIVATE KEY-----",
+            prefix + "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAA",
+            prefix + "c2gtZWQyNTUxOQAAACDkZXlkZWFkYmVlZmRlYWRiZWVmZGVhZGJlZWZkZWFk",
+            prefix + "-----END OPENSSH PRIVATE KEY-----",
+        ]
+    )
+    result = redact_secrets(report)
+    assert "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAA" not in result
+    assert "c2gtZWQyNTUxOQAAACDkZXlkZWFkYmVlZmRlYWRiZWVmZGVhZGJlZWZkZWFk" not in result
+    assert result.count(REDACTED) == 2
+    assert prefix + "-----BEGIN OPENSSH PRIVATE KEY-----" in result
+    assert prefix + "-----END OPENSSH PRIVATE KEY-----" in result
+    # No line is added or dropped.
+    assert len(result.split("\n")) == 4
+
+
+def test_pem_block_with_indented_body_is_redacted():
+    # (c) the block is quoted/indented inside the report.
+    report = (
+        "Certificate:\n"
+        "    -----BEGIN EC PRIVATE KEY-----\n"
+        "    MHcCAQEEIBnKrLZ0987654321abcdefghijklmnopqrstuvwxyzABCDEFGH\n"
+        "    -----END EC PRIVATE KEY-----"
+    )
+    result = redact_secrets(report)
+    assert "MHcCAQEEIBnKrLZ0987654321abcdefghijklmnopqrstuvwxyzABCDEFGH" not in result
+    assert "Certificate:" in result
+    assert "    -----BEGIN EC PRIVATE KEY-----" in result
+    assert "    -----END EC PRIVATE KEY-----" in result
+    assert REDACTED in result
+
+
+def test_truncated_pem_block_at_end_of_report_is_redacted():
+    # (d) BEGIN plus body, no END marker anywhere, nothing after it.
+    report = (
+        "Journal:\n"
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "MIIEpAIBAAKCAQEA1111111111111111111111111111111111111111111111\n"
+        "MIIEpAIBAAKCAQEA2222222222222222222222222222222222222222222222"
+    )
+    result = redact_secrets(report)
+    assert "1111111111" not in result
+    assert "2222222222" not in result
+    assert "Journal:" in result
+    assert "-----BEGIN RSA PRIVATE KEY-----" in result
+
+
+def test_truncated_pem_block_keeps_the_diagnostics_that_follow():
+    # (e) BEGIN plus body, no END marker, ordinary report lines after it.
+    report = (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "MIIEpAIBAAKCAQEA1234567890abcdefghijklmnopqrstuvwxyz\n"
+        "AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHH\n"
+        "Sound Card: DAC2 HD\n"
+        "Kernel: 6.6.31\n"
+        "Uptime: 3 days"
+    )
+    result = redact_secrets(report)
+    assert "MIIEpAIBAAKCAQEA1234567890abcdefghijklmnopqrstuvwxyz" not in result
+    assert "AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHH" not in result
+    assert result.endswith("Sound Card: DAC2 HD\nKernel: 6.6.31\nUptime: 3 days")
+
+
+def test_secret_after_truncated_pem_block_is_still_redacted():
+    # (f) the truncated block must not consume a later secret -- that line
+    # still has to go through the key/value redaction.
+    report = (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "MIIEpAIBAAKCAQEA1234567890abcdefghijklmnopqrstuvwxyz\n"
+        "Sound Card: DAC2 HD\n"
+        "password=hunter2\n"
+        "Kernel: 6.6.31"
+    )
+    result = redact_secrets(report)
+    assert "hunter2" not in result
+    assert f"password={REDACTED}" in result
+    assert "Sound Card: DAC2 HD" in result
+    assert "Kernel: 6.6.31" in result
+
+
+def test_truncated_block_does_not_reach_into_a_later_block():
+    # A later, unrelated block's END marker must not turn a truncated block
+    # into a terminated one -- that would redact the report in between.
+    report = (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "MIIEpAIBAAKCAQEAtruncated0123456789abcdefghijklmnop\n"
+        "Sound Card: DAC2 HD\n"
+        "Kernel: 6.6.31\n"
+        "-----BEGIN EC PRIVATE KEY-----\n"
+        "MHcCAQEEIBnKrLZsecondkey0123456789abcdefghijklmnopq\n"
+        "-----END EC PRIVATE KEY-----"
+    )
+    result = redact_secrets(report)
+    assert "MIIEpAIBAAKCAQEAtruncated0123456789abcdefghijklmnop" not in result
+    assert "MHcCAQEEIBnKrLZsecondkey0123456789abcdefghijklmnopq" not in result
+    assert "Sound Card: DAC2 HD" in result
+    assert "Kernel: 6.6.31" in result
+
+
+def test_encrypted_pem_headers_do_not_end_the_block():
+    # An encrypted PEM key carries RFC 1421 headers and a blank line before
+    # the base64 body; neither may be mistaken for the end of the block.
+    block = (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "Proc-Type: 4,ENCRYPTED\n"
+        "DEK-Info: AES-128-CBC,0123456789ABCDEF0123456789ABCDEF\n"
+        "\n"
+        "MIIEpAIBAAKCAQEAkeymaterial0123456789abcdefghijklmnopqXYZ\n"
+        "-----END RSA PRIVATE KEY-----"
+    )
+    result = redact_secrets(block)
+    assert "MIIEpAIBAAKCAQEAkeymaterial0123456789abcdefghijklmnopqXYZ" not in result
+    assert "-----END RSA PRIVATE KEY-----" in result
+
+
+def test_truncated_encrypted_pem_block_is_redacted():
+    report = (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "Proc-Type: 4,ENCRYPTED\n"
+        "DEK-Info: AES-128-CBC,0123456789ABCDEF0123456789ABCDEF\n"
+        "\n"
+        "MIIEpAIBAAKCAQEAkeymaterial0123456789abcdefghijklmnopqXYZ\n"
+        "Sound Card: DAC2 HD"
+    )
+    result = redact_secrets(report)
+    assert "MIIEpAIBAAKCAQEAkeymaterial0123456789abcdefghijklmnopqXYZ" not in result
+    assert result.endswith("Sound Card: DAC2 HD")

--- a/tests/test_supportinfo_redaction.py
+++ b/tests/test_supportinfo_redaction.py
@@ -238,6 +238,76 @@ def test_truncated_block_does_not_reach_into_a_later_block():
     assert "Kernel: 6.6.31" in result
 
 
+def test_truncated_pem_block_with_short_log_prefix_is_redacted():
+    # Round 5: a prefix with only two fields before the colon (classic
+    # syslog, "host sshd: ") used to leave the payload unrecognised, so the
+    # walk stopped at the first body line of a truncated block and emitted
+    # the whole key verbatim.
+    report = (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "host sshd: MIIEpAIBAAKCAQEA1234567890abcdefghijklmnopqrstuvwxyz\n"
+        "host sshd: MIIEpAIBAAKCAQEA0987654321zyxwvutsrqponmlkjihgfedcbaAB\n"
+        "Kernel: 6.6.31"
+    )
+    result = redact_secrets(report)
+    assert "MIIEpAIBAAKCAQEA1234567890abcdefghijklmnopqrstuvwxyz" not in result
+    assert "MIIEpAIBAAKCAQEA0987654321zyxwvutsrqponmlkjihgfedcbaAB" not in result
+    assert result.count(REDACTED) == 2
+    assert "Kernel: 6.6.31" in result
+
+
+def test_truncated_pem_block_with_short_iso_journal_prefix_is_redacted():
+    # Round 5: "journalctl -o short-iso --no-hostname" drops the hostname,
+    # leaving two fields before the colon.
+    prefix = "2026-08-07T10:00:01+0200 sshd[123]: "
+    report = "\n".join(
+        [
+            prefix + "-----BEGIN OPENSSH PRIVATE KEY-----",
+            prefix + "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAA",
+            prefix + "c2gtZWQyNTUxOQAAACDkZXlkZWFkYmVlZmRlYWRiZWVmZGVhZGJlZWZkZWFk",
+            "Sound Card: DAC2 HD",
+        ]
+    )
+    result = redact_secrets(report)
+    assert "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAA" not in result
+    assert "c2gtZWQyNTUxOQAAACDkZXlkZWFkYmVlZmRlYWRiZWVmZGVhZGJlZWZkZWFk" not in result
+    assert prefix + REDACTED in result
+    assert result.endswith("Sound Card: DAC2 HD")
+
+
+def test_line_count_is_never_changed():
+    # The invariant the whole PEM design rests on: one input line produces
+    # exactly one output line, so redaction can never delete report content.
+    reports = [
+        "Sound Card: DAC2 HD\nKernel: 6.6.31\nUptime: 3 days",
+        (
+            "-----BEGIN RSA PRIVATE KEY-----\n"
+            "MIIEpAIBAAKCAQEA1234567890abcdefghijklmnop\n"
+            "-----END RSA PRIVATE KEY-----\n"
+            "Kernel: 6.6.31"
+        ),
+        (
+            "host sshd: -----BEGIN RSA PRIVATE KEY-----\n"
+            "host sshd: MIIEpAIBAAKCAQEA1234567890abcdefghijklmnop\n"
+            "host sshd: MIIEpAIBAAKCAQEA0987654321zyxwvutsrqponmlk\n"
+            "\n"
+            "Sound Card: DAC2 HD\n"
+            "password=hunter2"
+        ),
+        (
+            "-----BEGIN RSA PRIVATE KEY-----\n"
+            "Proc-Type: 4,ENCRYPTED\n"
+            "\n"
+            "MIIEpAIBAAKCAQEA1234567890abcdefghijklmnop\n"
+            "-----END RSA PRIVATE KEY-----\n"
+            "\n"
+            "Uptime: 3 days\n"
+        ),
+    ]
+    for report in reports:
+        assert len(redact_secrets(report).split("\n")) == len(report.split("\n"))
+
+
 def test_encrypted_pem_headers_do_not_end_the_block():
     # An encrypted PEM key carries RFC 1421 headers and a blank line before
     # the base64 body; neither may be mistaken for the end of the block.

--- a/tests/test_supportinfo_report.py
+++ b/tests/test_supportinfo_report.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from unittest.mock import patch
 
 from configurator import supportinfo
@@ -68,3 +69,28 @@ def test_main_default_output_is_text(capsys):
         supportinfo.main([])
     out = capsys.readouterr().out
     assert out.startswith("## System")
+
+
+def test_render_text_empty_dict_section_renders_none():
+    text = supportinfo.render_text({"System": {}})
+    assert "## System" in text
+    assert "(none)" in text
+
+
+def test_main_verbose_flag_leaves_stdout_unchanged(capsys):
+    root_logger = logging.getLogger()
+    original_level = root_logger.level
+    try:
+        with patch.object(supportinfo, "build_report", return_value=dict(REPORT)):
+            supportinfo.main([])
+            default_out = capsys.readouterr().out
+            default_level = root_logger.level
+
+            supportinfo.main(["--verbose"])
+            verbose_out = capsys.readouterr().out
+            verbose_level = root_logger.level
+    finally:
+        root_logger.setLevel(original_level)
+
+    assert default_out == verbose_out
+    assert default_level != verbose_level

--- a/tests/test_supportinfo_report.py
+++ b/tests/test_supportinfo_report.py
@@ -1,0 +1,70 @@
+import json
+from unittest.mock import patch
+
+from configurator import supportinfo
+
+
+REPORT = {
+    "System": {"Pi Model": "Raspberry Pi 5", "Sound Card": "DAC2 HD"},
+    "OS": {"OS": "Debian GNU/Linux 13 (trixie)", "Kernel": "6.12.0-rpi"},
+    "Packages": "hifiberry-configurator 2.15.0",
+    "Services": "mpd.service loaded active running",
+    "Disk": "/dev/sda1  30G  4G  25G  15% /",
+    "Recent errors": "Aug 07 10:00:01 host mount[1]: password=hunter2",
+}
+
+
+def test_render_text_has_a_section_per_key():
+    text = supportinfo.render_text(REPORT)
+    for section in REPORT:
+        assert f"## {section}" in text
+
+
+def test_render_text_renders_dicts_as_name_value_lines():
+    text = supportinfo.render_text(REPORT)
+    assert "Pi Model: Raspberry Pi 5" in text
+
+
+def test_render_text_redacts_secrets():
+    text = supportinfo.render_text(REPORT)
+    assert "hunter2" not in text
+    assert supportinfo.REDACTED in text
+
+
+def test_build_report_collects_every_section():
+    with patch.object(supportinfo, "collect_system", return_value={"Pi Model": "Pi 5"}), \
+         patch.object(supportinfo, "collect_os", return_value={"Kernel": "6.12"}), \
+         patch.object(supportinfo, "collect_packages", return_value="pkg 1.0"), \
+         patch.object(supportinfo, "collect_services", return_value="unit"), \
+         patch.object(supportinfo, "collect_journal", return_value="err"), \
+         patch.object(supportinfo, "collect_disk", return_value="df"):
+        report = supportinfo.build_report()
+    assert set(report) == {"System", "OS", "Packages", "Services", "Disk", "Recent errors"}
+
+
+def test_redact_report_walks_nested_values():
+    report = {
+        "System": {"Pi Model": "Pi 5", "Note": "psk=topsecret"},
+        "Recent errors": "password=hunter2",
+    }
+    result = supportinfo.redact_report(report)
+    assert result["System"]["Pi Model"] == "Pi 5"
+    assert result["System"]["Note"] == f"psk={supportinfo.REDACTED}"
+    assert result["Recent errors"] == f"password={supportinfo.REDACTED}"
+
+
+def test_main_json_output_is_valid_json_and_redacted(capsys):
+    with patch.object(supportinfo, "build_report", return_value=dict(REPORT)):
+        exit_code = supportinfo.main(["--json"])
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    parsed = json.loads(out)
+    assert parsed["System"]["Sound Card"] == "DAC2 HD"
+    assert "hunter2" not in out
+
+
+def test_main_default_output_is_text(capsys):
+    with patch.object(supportinfo, "build_report", return_value=dict(REPORT)):
+        supportinfo.main([])
+    out = capsys.readouterr().out
+    assert out.startswith("## System")


### PR DESCRIPTION
Adds a config-supportinfo command that collects a redacted diagnostic report for bug reports. Needed by the new issue forms in hifiberry-os.