### PR TITLE
supportinfo: dedupe flapping journal errors, drop uninstalled packages, hide hostname

### DIFF
--- a/configurator/_version.py
+++ b/configurator/_version.py
@@ -4,7 +4,7 @@ Version information for HiFiBerry Configurator
 Single source of truth for version number
 """
 
-__version__ = "2.15.0"
+__version__ = "2.15.1"
 __version_info__ = tuple(map(int, __version__.split('.')))
 
 # For backward compatibility

--- a/configurator/supportinfo.py
+++ b/configurator/supportinfo.py
@@ -298,11 +298,22 @@ def collect_packages() -> str:
 
     dpkg-query exits non-zero for patterns that match nothing, which is normal
     here -- most systems have only a few players installed. check=False in
-    _run keeps the matches we did get.
+    _run keeps the matches we did get. A pattern can also match a package
+    dpkg merely knows about (e.g. it was removed but not purged) rather than
+    one that is installed; dpkg-query prints that as a line with an empty
+    version field ("librespot "), which reads as broken output in a bug
+    report, so those lines are dropped here.
     """
-    return _run(
+    raw = _run(
         ["dpkg-query", "-W", "-f=${Package} ${Version}\n"] + PACKAGE_PATTERNS
     )
+    kept = []
+    for line in raw.splitlines():
+        parts = line.split(" ", 1)
+        version = parts[1].strip() if len(parts) > 1 else ""
+        if version:
+            kept.append(line)
+    return "\n".join(kept)
 
 
 def collect_services() -> str:
@@ -313,12 +324,81 @@ def collect_services() -> str:
     )
 
 
+# journalctl's default output starts every line with a timestamp
+# ("Aug 07 09:54:42"); with --no-hostname the hostname field that used to
+# follow it is gone, so everything after the timestamp is "IDENTIFIER[PID]:
+# MESSAGE". That tail is what two occurrences of the same error are
+# compared on -- the timestamp itself must not be part of the key, or every
+# occurrence of an otherwise identical message would count as distinct.
+_JOURNAL_TIMESTAMP = re.compile(r"^(\w{3}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2})\s+(.*)$")
+
+
+def _dedup_journal(text: str, keep: int) -> str:
+    """Collapse repeated journal messages into one entry each.
+
+    A single restart-looping unit can otherwise fill the whole window with
+    identical lines and crowd out every other error, which is exactly what a
+    bug report needs to show. The text is walked once, in the chronological
+    order journalctl prints it, keyed on everything after the timestamp; a
+    repeat updates the existing entry's timestamp to the latest occurrence
+    and bumps its count rather than appending a new line, so a unit that
+    failed 190 times occupies one slot, not 190. At most `keep` distinct
+    entries are kept: the most recently-first-seen ones, i.e. the last
+    `keep` messages to appear for the first time in the input, still shown
+    in that same chronological order.
+    """
+    if not text:
+        return text
+
+    order = []
+    entries = {}
+    for line in text.splitlines():
+        match = _JOURNAL_TIMESTAMP.match(line)
+        if match:
+            timestamp, message = match.group(1), match.group(2)
+        else:
+            timestamp, message = None, line
+        if message in entries:
+            entry = entries[message]
+            entry["count"] += 1
+            if timestamp:
+                entry["timestamp"] = timestamp
+        else:
+            entries[message] = {"timestamp": timestamp, "count": 1}
+            order.append(message)
+
+    kept = order[-keep:] if keep > 0 else []
+    rendered = []
+    for message in kept:
+        entry = entries[message]
+        prefix = f"{entry['timestamp']} " if entry["timestamp"] else ""
+        suffix = f" (x{entry['count']})" if entry["count"] > 1 else ""
+        rendered.append(f"{prefix}{message}{suffix}")
+    return "\n".join(rendered)
+
+
 def collect_journal(lines: int = 40) -> str:
-    """The most recent errors from the current boot."""
-    return _run(
-        ["journalctl", "-b", "-p", "err", "--no-pager", "-n", str(lines)],
+    """The most recent distinct errors from the current boot.
+
+    A flapping unit can produce dozens of identical lines in a row, so
+    journalctl is asked for a much wider window than will be shown (ten
+    times `lines`, with a floor of 200) and the result is collapsed down to
+    at most `lines` distinct entries by _dedup_journal -- `lines` keeps its
+    meaning from the caller's point of view, the number of entries shown.
+    --no-hostname keeps the hostname (which regularly contains someone's
+    real name) out of the report, the same reason Task 2 leaves Hostname out
+    of the System section; the resulting "timestamp identifier: message"
+    prefix shape is already handled by the PEM redaction walk.
+    """
+    fetch = max(lines * 10, 200)
+    raw = _run(
+        [
+            "journalctl", "-b", "-p", "err", "--no-pager", "--no-hostname",
+            "-n", str(fetch),
+        ],
         timeout=20,
     )
+    return _dedup_journal(raw, lines)
 
 
 def collect_disk() -> str:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+hifiberry-configurator (2.15.1) stable; urgency=medium
+
+  * config-supportinfo: deduplicate the "Recent errors" section so a single
+    flapping unit no longer crowds out every other error, keep at most the
+    requested number of distinct entries (each showing its most recent
+    timestamp and an occurrence count), and pass --no-hostname to journalctl
+    so the hostname does not defeat the report's redaction of it.
+  * config-supportinfo: drop Packages lines with an empty version (a pattern
+    matching a package dpkg knows about but that isn't installed), which
+    previously showed as broken-looking output.
+
+ -- HiFiBerry <support@hifiberry.com>  Fri, 07 Aug 2026 14:00:00 +0200
+
 hifiberry-configurator (2.15.0) stable; urgency=medium
 
   * Add config-supportinfo, which collects a redacted diagnostic report

--- a/tests/test_supportinfo_commands.py
+++ b/tests/test_supportinfo_commands.py
@@ -57,13 +57,86 @@ def test_collect_packages_asks_dpkg_for_the_known_patterns():
     assert "mpd" in cmd
 
 
-def test_collect_journal_passes_the_line_limit():
+def test_collect_journal_requests_a_wider_window_than_it_displays():
+    # journalctl is asked for far more lines than `lines` requests (10x,
+    # floor 200), so a flapping unit's repeats don't crowd the rare errors
+    # in the recent past out of the fetch entirely -- dedup happens
+    # afterwards, in _dedup_journal.
     with patch("subprocess.run", return_value=_completed("some error")) as run:
         supportinfo.collect_journal(lines=5)
     cmd = run.call_args[0][0]
     assert cmd[0] == "journalctl"
-    assert "-n" in cmd and "5" in cmd
+    assert "-n" in cmd
+    assert cmd[cmd.index("-n") + 1] == "200"  # max(5 * 10, 200)
     assert "-p" in cmd and "err" in cmd
+
+
+def test_collect_journal_scales_the_fetch_with_the_requested_line_count():
+    with patch("subprocess.run", return_value=_completed("")) as run:
+        supportinfo.collect_journal(lines=30)
+    cmd = run.call_args[0][0]
+    assert cmd[cmd.index("-n") + 1] == "300"  # 30 * 10 > the 200 floor
+
+
+def test_collect_journal_passes_no_hostname_so_the_hostname_never_reaches_the_report():
+    with patch("subprocess.run", return_value=_completed("")) as run:
+        supportinfo.collect_journal()
+    cmd = run.call_args[0][0]
+    assert "--no-hostname" in cmd
+
+
+def test_collect_journal_deduplicates_a_flapping_unit_and_keeps_the_count():
+    repeated = "\n".join(
+        f"Aug 07 09:{50 + i:02d}:00 systemd[1]: Failed to start "
+        "ble-provisioning.service - HiFiBerry BLE WiFi Provisioning."
+        for i in range(5)
+    )
+    with patch("subprocess.run", return_value=_completed(repeated)):
+        result = supportinfo.collect_journal(lines=40)
+    lines = result.splitlines()
+    assert len(lines) == 1
+    assert "Failed to start ble-provisioning.service" in lines[0]
+    assert "(x5)" in lines[0]
+    assert "09:54:00" in lines[0]  # the most recent occurrence's timestamp
+
+
+def test_collect_journal_keeps_a_rare_error_distinct_from_a_dominant_repeat():
+    # The whole point of dedup: a single distinct error must not be pushed
+    # out just because another message dominates the window by volume.
+    raw = "\n".join(
+        ["Aug 07 09:00:00 kernel: rare disk I/O error on sda1"]
+        + [
+            f"Aug 07 09:{10 + i:02d}:00 systemd[1]: Failed to start "
+            "ble-provisioning.service - HiFiBerry BLE WiFi Provisioning."
+            for i in range(39)
+        ]
+    )
+    with patch("subprocess.run", return_value=_completed(raw)):
+        result = supportinfo.collect_journal(lines=40)
+    lines = result.splitlines()
+    assert len(lines) == 2
+    assert "rare disk I/O error on sda1" in lines[0]
+    assert "(x39)" in lines[1]
+    # chronological order: the rare error was first, the repeat came after
+    assert result.index("rare disk I/O error") < result.index("ble-provisioning")
+
+
+def test_collect_packages_drops_entries_with_no_version():
+    # dpkg knows the name (it's in a PACKAGE_PATTERNS entry) but nothing of
+    # that name is installed, so dpkg-query prints the name with an empty
+    # version field -- that reads as broken output in a bug report.
+    raw = (
+        "hifiberry-configurator 2.15.0\n"
+        "librespot \n"
+        "mpd \n"
+        "shairport-sync \n"
+        "squeezelite \n"
+    )
+    with patch("subprocess.run", return_value=_completed(raw)):
+        result = supportinfo.collect_packages()
+    assert result == "hifiberry-configurator 2.15.0"
+    assert "librespot" not in result
+    assert "shairport-sync" not in result
 
 
 def test_collect_services_lists_audio_units():


### PR DESCRIPTION
## Summary
Follow-up fixes to `config-supportinfo` found by inspecting the real report from a Raspberry Pi 4 running HiFiBerryOS trixie:

- **Recent errors section was worthless on a device with a flapping unit.** A single restart-looping service (`ble-provisioning.service`) filled all 40 shown lines with the identical message. `collect_journal` now asks `journalctl` for a much wider window (10x the requested line count, floor 200), then collapses identical messages into one entry each via a new `_dedup_journal` helper. Each entry keeps its most recent timestamp and states an occurrence count when seen more than once, in chronological order. `lines` keeps its meaning from the caller's side: the number of distinct entries shown.
- **Packages section listed entries with no version** (`librespot `, `mpd `, ...) for patterns dpkg recognises but that aren't installed. `collect_packages` now drops any line whose version field is empty.
- **Hostname reached the report despite being deliberately excluded from the System section.** `journalctl`'s default output prints the hostname on every line, defeating that. `collect_journal` now passes `--no-hostname`; the resulting prefix shape was already covered by the PEM-redaction hardening.
- Version bump to 2.15.1 with a changelog entry describing these three fixes.

## Test plan
- [x] `python3 -m pytest tests/test_supportinfo_commands.py -q` — 15 passed
- [x] `python3 -m pytest -q` (full suite) — 267 passed, 1 skipped
- [x] New tests cover: dedup occurrence count + most-recent timestamp, a distinct rare error surviving alongside a dominant repeat (with chronological ordering), the empty-version package filter, and `--no-hostname` present in the journalctl argument list.