### PR TITLE
config-supportinfo: redact Basic/Digest auth headers, fix package list

### DIFF
--- a/configurator/_version.py
+++ b/configurator/_version.py
@@ -4,7 +4,7 @@ Version information for HiFiBerry Configurator
 Single source of truth for version number
 """
 
-__version__ = "2.15.2"
+__version__ = "2.15.3"
 __version_info__ = tuple(map(int, __version__.split('.')))
 
 # For backward compatibility

--- a/configurator/supportinfo.py
+++ b/configurator/supportinfo.py
@@ -33,7 +33,20 @@ _KEY_VALUE = re.compile(
 
 _URL_CREDENTIALS = re.compile(r"(?i)\b([a-z][a-z0-9+.\-]*://[^\s:/@]+):([^\s@]+)@")
 
-_BEARER_TOKEN = re.compile(r"(?i)\b(Authorization\s*:\s*Bearer\s+)([^\s,;\"']+)")
+# HTTP "Authorization" headers that carry a credential. Bearer and Basic put
+# a single opaque token after the scheme name (a JWT, or base64 of
+# "user:pass" for Basic); Digest puts a comma-separated list of key="value"
+# fields (username, response hash, ...) that are individually just as
+# sensitive. Rather than parsing that structure, everything from the scheme
+# name to the end of the line is treated as the credential and replaced as
+# one unit -- simpler than the Digest fields, and still correct for the
+# single-token schemes. Only these three scheme names are recognised: a
+# scheme this does not know about (or a bare "Authorization:" with no
+# scheme at all) is left untouched rather than guessed at, so the scheme
+# name stays visible for whoever reads the report.
+_AUTH_CREDENTIAL = re.compile(
+    r"(?i)\b(Authorization\s*:\s*(?:Basic|Bearer|Digest)\s+)(\S.*)"
+)
 
 # --- PEM private-key blocks --------------------------------------------
 #
@@ -173,7 +186,8 @@ def redact_secrets(text: str) -> str:
     Handles four shapes: key/value pairs (password=..., psk: "...", and
     compound identifiers like WPA_PSK=... or AWS_SECRET_ACCESS_KEY=...),
     credentials embedded in URLs (smb://user:pass@host), HTTP
-    "Authorization: Bearer <token>" headers, and PEM private-key blocks
+    "Authorization: <scheme> <credential>" headers for the Basic, Bearer and
+    Digest schemes, and PEM private-key blocks
     (the body between a "-----BEGIN ... PRIVATE KEY-----" marker and its
     matching "-----END" marker -- or, if the block was truncated, e.g. by a
     log excerpt that cuts off mid-key, as far as the lines look like key
@@ -183,7 +197,7 @@ def redact_secrets(text: str) -> str:
     """
     text = _KEY_VALUE.sub(lambda m: f"{m.group(1)}{m.group(2)}{REDACTED}", text)
     text = _URL_CREDENTIALS.sub(lambda m: f"{m.group(1)}:{REDACTED}@", text)
-    text = _BEARER_TOKEN.sub(lambda m: f"{m.group(1)}{REDACTED}", text)
+    text = _AUTH_CREDENTIAL.sub(lambda m: f"{m.group(1)}{REDACTED}", text)
     text = _redact_pem_keys(text)
     return text
 
@@ -246,6 +260,8 @@ PACKAGE_PATTERNS = [
     "shairport-sync",
     "squeezelite",
     "raat",
+    "roomeq",
+    "nowplaying-sdl",
 ]
 
 SERVICE_PATTERNS = [

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,18 @@
+hifiberry-configurator (2.15.3) stable; urgency=medium
+
+  * config-supportinfo: redact "Authorization: Basic ..." and "Authorization:
+    Digest ..." headers, not just "Authorization: Bearer ...". Basic's
+    credential is a base64-encoded "user:pass" and was previously passed
+    through the report verbatim.
+  * config-supportinfo: add roomeq and nowplaying-sdl to the package-version
+    list (PACKAGE_PATTERNS) -- both already appeared in the service list, so
+    a DSP bug report showed the roomeq unit running but not which version of
+    it.
+  * config-supportinfo(1): fix the man page's version string, still reading
+    2.15.0 after the 2.15.1 changes.
+
+ -- HiFiBerry <support@hifiberry.com>  Fri, 07 Aug 2026 16:00:00 +0200
+
 hifiberry-configurator (2.15.2) stable; urgency=medium
 
   * config-detect: stop logging "No sound card detected to configure." when a

--- a/man/config-supportinfo.1
+++ b/man/config-supportinfo.1
@@ -1,4 +1,4 @@
-.TH CONFIG-SUPPORTINFO 1 "August 2026" "configurator 2.15.0" "HiFiBerry Configuration Tools"
+.TH CONFIG-SUPPORTINFO 1 "August 2026" "configurator 2.15.1" "HiFiBerry Configuration Tools"
 .SH NAME
 config-supportinfo \- collect a diagnostic report for bug reports
 .SH SYNOPSIS

--- a/tests/test_supportinfo_commands.py
+++ b/tests/test_supportinfo_commands.py
@@ -152,6 +152,15 @@ def test_package_patterns_drop_names_that_match_nothing_in_the_project():
     assert "roonbridge" not in supportinfo.PACKAGE_PATTERNS
 
 
+def test_package_patterns_cover_units_that_are_also_in_service_patterns():
+    # Final review, finding 2: roomeq and nowplaying-sdl were in
+    # SERVICE_PATTERNS (an earlier fix round updated the service list only),
+    # so a DSP bug report showed the roomeq unit running but no roomeq
+    # version.
+    assert "roomeq" in supportinfo.PACKAGE_PATTERNS
+    assert "nowplaying-sdl" in supportinfo.PACKAGE_PATTERNS
+
+
 def test_service_patterns_cover_the_units_missing_from_the_original_list():
     for pattern in (
         "nqptp*",

--- a/tests/test_supportinfo_redaction.py
+++ b/tests/test_supportinfo_redaction.py
@@ -61,6 +61,40 @@ def test_bearer_token_is_removed():
     assert redact_secrets(header) == f"Authorization: Bearer {REDACTED}"
 
 
+def test_basic_auth_credential_is_removed():
+    # Final review, finding 1: "Authorization: Basic <base64>" was not
+    # redacted at all. "am9lOmh1bnRlcjI=" decodes to "joe:hunter2".
+    header = "Authorization: Basic am9lOmh1bnRlcjI="
+    result = redact_secrets(header)
+    assert result == f"Authorization: Basic {REDACTED}"
+    assert "am9lOmh1bnRlcjI=" not in result
+    assert "joe" not in result
+    assert "hunter2" not in result
+
+
+def test_digest_auth_credential_is_removed():
+    header = (
+        'Authorization: Digest username="joe", realm="protected area", '
+        'nonce="abc123", uri="/", response="deadbeefcafefeed"'
+    )
+    result = redact_secrets(header)
+    assert result == f"Authorization: Digest {REDACTED}"
+    assert "joe" not in result
+    assert "deadbeefcafefeed" not in result
+
+
+def test_unrecognised_auth_scheme_does_not_crash_and_keeps_the_scheme_name():
+    # Only Basic, Bearer and Digest carry a credential this module knows how
+    # to redact. A scheme it doesn't recognise -- or a bare "Authorization:"
+    # with no scheme at all -- must not crash, and the scheme name has to
+    # stay visible so a maintainer can tell which scheme was in play.
+    header = "Authorization: Negotiate YIIFxQYGKwYBBQUCoIIF"
+    assert redact_secrets(header) == header
+
+    header = "Authorization: sometoken123"
+    assert redact_secrets(header) == header
+
+
 def test_pem_private_key_block_is_removed():
     # Finding 3: PEM private-key blocks, everything between the BEGIN and
     # the matching END marker.


### PR DESCRIPTION
## Summary
Follow-up on the config-supportinfo redaction work from 2.15.0/2.15.1. A final review found three defects:

- **Basic/Digest auth headers leaked.** Only `Authorization: Bearer <token>` was redacted; `Authorization: Basic <base64>` passed through verbatim (`am9lOmh1bnRlcjI=` decodes to `joe:hunter2`). Generalized the existing `_BEARER_TOKEN` pattern into `_AUTH_CREDENTIAL`, covering Basic, Bearer and Digest as one mechanism instead of a one-off pattern. Unrecognised schemes (or a bare `Authorization:` with none) are left untouched, so the scheme name stays visible. Key/value, URL-credential and PEM redaction are untouched.
- **`PACKAGE_PATTERNS` missing `roomeq` and `nowplaying-sdl`**, both already in `SERVICE_PATTERNS` — a DSP bug report showed the roomeq unit running but not its version. Added both. Cross-checked the two lists against `debian/control` across hifiberry-os: every other `SERVICE_PATTERNS`-only name (`config-server`, `sigmatcpserver`, `aes67`, `usbaudio`, `sendspin`, `analoginput`, `acr-webmcp`, `sambamount`, `nqptp`) is already covered by the `hifiberry-*` wildcard, so no further additions needed.
- **`man/config-supportinfo.1`** still said "configurator 2.15.0" though the page documents behaviour shipped in 2.15.1.

Released as 2.15.3 (2.15.2 was already taken on `main` by an unrelated soundcard fix that landed first).

## Test plan
- [x] Added tests for Basic and Digest header redaction, asserting the decoded credential does not survive
- [x] Added a test for an unrecognised auth scheme: no crash, scheme name stays visible
- [x] Added tests for the `roomeq`/`nowplaying-sdl` package-pattern additions
- [x] Full suite: `python3 -m pytest -q` → 273 passed, 1 skipped (all pre-existing tests pass unchanged)