### PR TITLE
config-supportinfo: report enabled state alongside running state

### DIFF
--- a/configurator/_version.py
+++ b/configurator/_version.py
@@ -4,7 +4,7 @@ Version information for HiFiBerry Configurator
 Single source of truth for version number
 """
 
-__version__ = "2.15.3"
+__version__ = "2.15.4"
 __version_info__ = tuple(map(int, __version__.split('.')))
 
 # For backward compatibility

--- a/configurator/supportinfo.py
+++ b/configurator/supportinfo.py
@@ -332,12 +332,122 @@ def collect_packages() -> str:
     return "\n".join(kept)
 
 
+# Marker _run() puts at the start of every failure string it returns,
+# whatever the underlying reason. Used here to tell "the command ran and
+# told us this unit doesn't exist" apart from "we don't know, the command
+# didn't run" -- the two must not be treated the same when deciding what to
+# suppress (see _merge_service_states).
+_COMMAND_FAILED_PREFIX = "(command failed:"
+
+
+def _parse_list_units(raw: str) -> dict:
+    """Parse `systemctl list-units` output into {unit: "load active sub"}.
+
+    Each line is "UNIT LOAD ACTIVE SUB DESCRIPTION"; DESCRIPTION may itself
+    contain spaces (or be absent, e.g. for a "not-found" row), so only the
+    first four fields are taken. A line with fewer than four fields is not
+    a unit row -- it is skipped rather than raising, since a failed command
+    is handled by the caller before this is ever called on its output.
+    """
+    states = {}
+    for line in raw.splitlines():
+        parts = line.split(None, 4)
+        if len(parts) < 4:
+            continue
+        unit, load, active, sub = parts[:4]
+        states[unit] = f"{load} {active} {sub}"
+    return states
+
+
+def _parse_list_unit_files(raw: str) -> dict:
+    """Parse `systemctl list-unit-files` output into {unit: enable_state}.
+
+    Each line is "UNIT FILE STATE", optionally followed by a VENDOR PRESET
+    column on newer systemd -- only the first two fields are read, so both
+    shapes work.
+    """
+    states = {}
+    for line in raw.splitlines():
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        unit, state = parts[0], parts[1]
+        states[unit] = state
+    return states
+
+
+def _merge_service_states(units_raw: str, files_raw: str) -> str:
+    """Combine running state and enabled state into one row per unit.
+
+    `systemctl list-units` answers "is it running now"; `list-unit-files`
+    answers "will it start on the next boot". A report that only carries
+    the former is exactly the gap this exists to close -- "player works
+    until I reboot, then it doesn't" is settled by the enabled state, not
+    by whatever happens to be running at the moment someone runs
+    config-supportinfo. The two are merged into one row per unit, not two
+    separate sections, so a maintainer reading the report never has to
+    cross-reference a unit name between them to answer both questions.
+
+    Units that are neither installed nor enabled are dropped. SERVICE_PATTERNS
+    matches every player this project supports, and most systems have only
+    one or two of them installed; a "not-found"/"not-found" row for each of
+    the rest would bury the units that actually matter under noise nobody
+    reads. This suppression only fires when *both* commands succeeded and
+    *both* agree the unit is absent -- a command failure must never be
+    read as "not installed", so a unit is kept (with "unknown" in place of
+    whichever half failed) whenever either query could not run.
+    """
+    units_failed = units_raw.startswith(_COMMAND_FAILED_PREFIX)
+    files_failed = files_raw.startswith(_COMMAND_FAILED_PREFIX)
+
+    running = {} if units_failed else _parse_list_units(units_raw)
+    enabled = {} if files_failed else _parse_list_unit_files(files_raw)
+
+    rows = []
+    for unit in sorted(set(running) | set(enabled)):
+        run_state = running.get(unit)
+        if run_state is None:
+            run_state = "unknown" if units_failed else "not-found"
+        enable_state = enabled.get(unit)
+        if enable_state is None:
+            enable_state = "unknown" if files_failed else "not-found"
+
+        if not units_failed and not files_failed:
+            load_state = run_state.split(" ", 1)[0]
+            if load_state == "not-found" and enable_state == "not-found":
+                continue
+
+        rows.append(f"{unit} {run_state} [enabled: {enable_state}]")
+
+    lines = []
+    if units_failed:
+        lines.append(f"(running state unavailable: {units_raw})")
+    if files_failed:
+        lines.append(f"(enabled state unavailable: {files_raw})")
+    if rows:
+        lines.append("UNIT LOAD ACTIVE SUB ENABLED")
+        lines.extend(rows)
+    return "\n".join(lines)
+
+
 def collect_services() -> str:
-    """State of the audio-related systemd units."""
-    return _run(
+    """Running and enabled state of the audio-related systemd units.
+
+    Two systemctl calls are needed because they report different things --
+    see _merge_service_states for why they are combined into one row per
+    unit rather than kept as separate sections. Each call goes through
+    _run independently, so one failing (e.g. systemctl missing entirely)
+    still leaves the other half of the picture intact.
+    """
+    units_raw = _run(
         ["systemctl", "list-units", "--all", "--no-legend", "--no-pager"]
         + SERVICE_PATTERNS
     )
+    files_raw = _run(
+        ["systemctl", "list-unit-files", "--no-legend", "--no-pager"]
+        + SERVICE_PATTERNS
+    )
+    return _merge_service_states(units_raw, files_raw)
 
 
 # journalctl's default output starts every line with a timestamp

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,19 @@
+hifiberry-configurator (2.15.4) stable; urgency=medium
+
+  * config-supportinfo: report each service's enabled state (will it start
+    on the next boot) alongside its running state, merged into one row per
+    unit in the Services section. collect_services() previously ran only
+    `systemctl list-units`, which says whether a unit is active right now
+    and says nothing about whether it is enabled -- the governing spec
+    asked for the enabled state and it was never delivered. "Player works
+    until I reboot, then it doesn't" is a common report, and the enabled
+    state is what settles it. Units that are neither installed nor enabled
+    (most of SERVICE_PATTERNS, on any given system) are dropped from the
+    merged output so the section does not balloon into a wall of
+    "not-found" rows for players nobody has installed.
+
+ -- HiFiBerry <support@hifiberry.com>  Fri, 07 Aug 2026 17:00:00 +0200
+
 hifiberry-configurator (2.15.3) stable; urgency=medium
 
   * config-supportinfo: redact "Authorization: Basic ..." and "Authorization:

--- a/man/config-supportinfo.1
+++ b/man/config-supportinfo.1
@@ -1,4 +1,4 @@
-.TH CONFIG-SUPPORTINFO 1 "August 2026" "configurator 2.15.1" "HiFiBerry Configuration Tools"
+.TH CONFIG-SUPPORTINFO 1 "August 2026" "configurator 2.15.4" "HiFiBerry Configuration Tools"
 .SH NAME
 config-supportinfo \- collect a diagnostic report for bug reports
 .SH SYNOPSIS
@@ -8,7 +8,9 @@ config-supportinfo \- collect a diagnostic report for bug reports
 .B config-supportinfo
 collects hardware, package, service and error information into a single block
 of text that can be pasted into a bug report on
-https://github.com/hifiberry/hifiberry-os/issues.
+https://github.com/hifiberry/hifiberry-os/issues. For each audio-related
+systemd unit, the Services section reports both whether it is running now
+and whether it is enabled to start on the next boot.
 .PP
 Passwords, pre-shared keys, tokens and credentials embedded in URLs are
 replaced before anything is printed. Device UUID and hostnames are not

--- a/tests/test_supportinfo_commands.py
+++ b/tests/test_supportinfo_commands.py
@@ -175,3 +175,170 @@ def test_service_patterns_cover_the_units_missing_from_the_original_list():
         "sambamount*",
     ):
         assert pattern in supportinfo.SERVICE_PATTERNS
+
+
+# --- Enabled state (systemctl list-unit-files) --------------------------
+#
+# collect_services() used to report only whether a unit was running right
+# now (systemctl list-units). It did not say whether the unit would start
+# again after a reboot -- the "player works until I reboot, then it
+# doesn't" report is settled by the enabled state, not by what happens to
+# be running at the moment someone runs config-supportinfo. These tests
+# cover the merged output: both systemctl calls fire with the right
+# arguments, running and enabled state land in the same row, an
+# enabled-but-not-running unit and a running-but-disabled unit are both
+# shown (they are real, distinct diagnostic situations), noise from units
+# that are neither installed nor enabled is dropped, and a failing
+# list-unit-files call leaves the running-state half of the report intact.
+
+
+def _systemctl_side_effect(units_stdout=None, units_result=None,
+                            files_stdout=None, files_result=None):
+    """subprocess.run side_effect that tells list-units and list-unit-files apart."""
+
+    def run(cmd, **kwargs):
+        if cmd[1] == "list-units":
+            if units_result is not None:
+                return units_result
+            return _completed(units_stdout or "")
+        assert cmd[1] == "list-unit-files"
+        if files_result is not None:
+            return files_result
+        return _completed(files_stdout or "")
+
+    return run
+
+
+def test_collect_services_queries_both_list_units_and_list_unit_files():
+    with patch(
+        "subprocess.run", side_effect=_systemctl_side_effect()
+    ) as run:
+        supportinfo.collect_services()
+    assert run.call_count == 2
+    commands = [call.args[0] for call in run.call_args_list]
+
+    units_cmd = next(c for c in commands if c[1] == "list-units")
+    assert units_cmd[0] == "systemctl"
+    assert "--all" in units_cmd
+    assert "--no-legend" in units_cmd
+    assert "--no-pager" in units_cmd
+    assert "mpd*" in units_cmd
+
+    files_cmd = next(c for c in commands if c[1] == "list-unit-files")
+    assert files_cmd[0] == "systemctl"
+    assert "--no-legend" in files_cmd
+    assert "--no-pager" in files_cmd
+    assert "mpd*" in files_cmd
+    # list-unit-files has no running units to enumerate, so it takes no --all
+    assert "--all" not in files_cmd
+
+
+def test_collect_services_merges_running_and_enabled_state_in_one_row():
+    with patch(
+        "subprocess.run",
+        side_effect=_systemctl_side_effect(
+            units_stdout="mpd.service loaded active running Music Player Daemon",
+            files_stdout="mpd.service enabled enabled",
+        ),
+    ):
+        result = supportinfo.collect_services()
+    lines = [l for l in result.splitlines() if l.startswith("mpd.service")]
+    assert len(lines) == 1
+    line = lines[0]
+    assert "loaded" in line and "active" in line and "running" in line
+    assert "enabled" in line
+
+
+def test_collect_services_shows_an_enabled_but_not_running_unit():
+    # Real diagnostic situation: the unit will start on the next boot but
+    # is not running right now (crashed, never started this session, ...).
+    with patch(
+        "subprocess.run",
+        side_effect=_systemctl_side_effect(
+            units_stdout="shairport-sync.service loaded inactive dead",
+            files_stdout="shairport-sync.service enabled enabled",
+        ),
+    ):
+        result = supportinfo.collect_services()
+    line = next(l for l in result.splitlines() if l.startswith("shairport-sync.service"))
+    assert "inactive" in line
+    assert "enabled: enabled" in line
+
+
+def test_collect_services_shows_a_running_but_disabled_unit():
+    # Real diagnostic situation: works today, will not come back after a
+    # reboot -- exactly the report this feature exists to settle.
+    with patch(
+        "subprocess.run",
+        side_effect=_systemctl_side_effect(
+            units_stdout="mpd.service loaded active running",
+            files_stdout="mpd.service disabled disabled",
+        ),
+    ):
+        result = supportinfo.collect_services()
+    line = next(l for l in result.splitlines() if l.startswith("mpd.service"))
+    assert "active" in line and "running" in line
+    assert "enabled: disabled" in line
+
+
+def test_collect_services_drops_units_neither_installed_nor_enabled():
+    # squeezelite is a SERVICE_PATTERNS entry but is not installed on most
+    # systems -- systemctl reports it "not-found" in both calls, and that
+    # combination must not survive into the report as noise.
+    with patch(
+        "subprocess.run",
+        side_effect=_systemctl_side_effect(
+            units_stdout=(
+                "mpd.service loaded active running\n"
+                "squeezelite.service not-found inactive dead"
+            ),
+            files_stdout="mpd.service enabled enabled",
+        ),
+    ):
+        result = supportinfo.collect_services()
+    assert "squeezelite" not in result
+    assert "mpd.service" in result
+
+
+def test_collect_services_keeps_running_state_when_list_unit_files_fails():
+    # _run() reports failures as strings rather than raising; a missing or
+    # failing systemctl on one call must not blank out the other half of
+    # the report.
+    with patch(
+        "subprocess.run",
+        side_effect=_systemctl_side_effect(
+            units_stdout="mpd.service loaded active running",
+            files_result=_failed("systemctl: command not found"),
+        ),
+    ):
+        result = supportinfo.collect_services()
+    assert "mpd.service" in result
+    assert "active" in result and "running" in result
+    assert "enabled: unknown" in result
+    assert "enabled state unavailable" in result
+
+
+def test_collect_services_keeps_enabled_state_when_list_units_fails():
+    with patch(
+        "subprocess.run",
+        side_effect=_systemctl_side_effect(
+            units_result=_failed("Failed to list units: access denied"),
+            files_stdout="mpd.service enabled enabled",
+        ),
+    ):
+        result = supportinfo.collect_services()
+    assert "mpd.service" in result
+    assert "enabled: enabled" in result
+    assert "unknown" in result
+    assert "running state unavailable" in result
+
+
+def test_merge_service_states_never_treats_a_failure_as_not_found():
+    # Direct check on the merge function: even if both calls fail, no unit
+    # can be reported as "not-found" from that -- there is simply no data.
+    result = supportinfo._merge_service_states(
+        "(command failed: no systemctl)", "(command failed: no systemctl)"
+    )
+    assert "not-found" not in result
+    assert "running state unavailable" in result
+    assert "enabled state unavailable" in result


### PR DESCRIPTION
## Summary
- `collect_services()` previously reported only whether a unit is running right now (`systemctl list-units`), never whether it is enabled to start on the next boot. The governing spec asked for the enabled state and it was never delivered -- "player works until I reboot, then it doesn't" is a common report, and the enabled state is what settles it.
- `collect_services()` now also runs `systemctl list-unit-files` and merges both into one row per unit in the existing Services section, so a reader can see running state and enabled state together without cross-referencing.
- Units that are neither installed nor enabled (most of `SERVICE_PATTERNS`, on any given system) are dropped from the merged output, so the section doesn't balloon into a wall of "not-found" rows for players nobody has installed. Suppression only fires when both systemctl calls succeed and both agree the unit is absent -- a failing call is never read as "not installed".
- Bumped to 2.15.4 with a matching changelog entry and man page version string.

Uptime was also missing from the original spec's list; it is deliberately not added here (explicit call from the project owner).

## Test plan
- [x] `python3 -m pytest` -- 281 passed, 1 skipped (pre-existing skip, unrelated)
- [x] New tests cover: both systemctl commands' arguments, merged output shape, an enabled-but-not-running unit, a running-but-disabled unit, noise suppression for units that are neither installed nor enabled, and a failing `list-unit-files`/`list-units` call leaving the rest of the report intact