### PR TITLE
config-supportinfo: fix Services table alignment on real systemctl output

### DIFF
--- a/configurator/_version.py
+++ b/configurator/_version.py
@@ -4,7 +4,7 @@ Version information for HiFiBerry Configurator
 Single source of truth for version number
 """
 
-__version__ = "2.15.6"
+__version__ = "2.15.7"
 __version_info__ = tuple(map(int, __version__.split('.')))
 
 # For backward compatibility

--- a/configurator/_version.py
+++ b/configurator/_version.py
@@ -4,7 +4,7 @@ Version information for HiFiBerry Configurator
 Single source of truth for version number
 """
 
-__version__ = "2.15.4"
+__version__ = "2.15.5"
 __version_info__ = tuple(map(int, __version__.split('.')))
 
 # For backward compatibility

--- a/configurator/_version.py
+++ b/configurator/_version.py
@@ -4,7 +4,7 @@ Version information for HiFiBerry Configurator
 Single source of truth for version number
 """
 
-__version__ = "2.15.5"
+__version__ = "2.15.6"
 __version_info__ = tuple(map(int, __version__.split('.')))
 
 # For backward compatibility

--- a/configurator/supportinfo.py
+++ b/configurator/supportinfo.py
@@ -339,9 +339,24 @@ def collect_packages() -> str:
 # suppress (see _merge_service_states).
 _COMMAND_FAILED_PREFIX = "(command failed:"
 
+# Explicit stand-in for a column with nothing to say (e.g. ACTIVE/SUB for a
+# unit that only appeared in `list-unit-files`, never in `list-units`).
+# Never blank: a blank cell collapses the column count for that row and
+# breaks the alignment every other row relies on.
+_NO_VALUE = "-"
+
+# systemctl prefixes a unit-state glyph (a red "●" for a failed/not-found
+# unit) directly onto the UNIT column of `list-units` output, glyph-then-space,
+# ahead of the unit name -- unrelated to --no-legend, which only controls the
+# header/footer. Left in place it becomes the first whitespace-split token,
+# which shifts every following field over by one and corrupts the unit name
+# used as this row's dict key. Stripped unconditionally before parsing; a
+# normal line has nothing here to strip.
+_LEADING_GLYPH = re.compile(r"^[^\w\s]+\s+")
+
 
 def _parse_list_units(raw: str) -> dict:
-    """Parse `systemctl list-units` output into {unit: "load active sub"}.
+    """Parse `systemctl list-units` output into {unit: (load, active, sub)}.
 
     Each line is "UNIT LOAD ACTIVE SUB DESCRIPTION"; DESCRIPTION may itself
     contain spaces (or be absent, e.g. for a "not-found" row), so only the
@@ -351,11 +366,12 @@ def _parse_list_units(raw: str) -> dict:
     """
     states = {}
     for line in raw.splitlines():
+        line = _LEADING_GLYPH.sub("", line, count=1)
         parts = line.split(None, 4)
         if len(parts) < 4:
             continue
         unit, load, active, sub = parts[:4]
-        states[unit] = f"{load} {active} {sub}"
+        states[unit] = (load, active, sub)
     return states
 
 
@@ -374,6 +390,33 @@ def _parse_list_unit_files(raw: str) -> dict:
         unit, state = parts[0], parts[1]
         states[unit] = state
     return states
+
+
+def _render_service_rows(rows: list) -> list:
+    """Render (unit, load, active, sub, enabled) tuples as an aligned table.
+
+    Column widths are computed from exactly the rows being printed (post
+    suppression) plus their headers, then every UNIT/LOAD/ACTIVE/SUB cell is
+    left-padded to its column's width -- so the ENABLED column, and every
+    column before it, starts at the same character offset on every row,
+    header included. Padding is computed with plain str.ljust on the column
+    values only; the "  " separator between columns is added on top of
+    that, not folded into the width, so two adjacent equal-width columns
+    are never visually ambiguous.
+    """
+    headers = ("UNIT", "LOAD", "ACTIVE", "SUB")
+    widths = [
+        max(len(headers[i]), max(len(row[i]) for row in rows))
+        for i in range(len(headers))
+    ]
+
+    def fixed_columns(values):
+        return "  ".join(value.ljust(width) for value, width in zip(values, widths))
+
+    lines = [fixed_columns(headers) + "  ENABLED"]
+    for unit, load, active, sub, enabled in rows:
+        lines.append(fixed_columns((unit, load, active, sub)) + f"  [enabled: {enabled}]")
+    return lines
 
 
 def _merge_service_states(units_raw: str, files_raw: str) -> str:
@@ -396,6 +439,12 @@ def _merge_service_states(units_raw: str, files_raw: str) -> str:
     *both* agree the unit is absent -- a command failure must never be
     read as "not installed", so a unit is kept (with "unknown" in place of
     whichever half failed) whenever either query could not run.
+
+    A unit missing from `list-units` (it only appeared in list-unit-files,
+    e.g. a static unit with no loaded instance) still gets a full-width
+    ACTIVE/SUB placeholder rather than being collapsed to a single word --
+    see _render_service_rows, which needs every row to carry the same
+    number of columns to align them.
     """
     units_failed = units_raw.startswith(_COMMAND_FAILED_PREFIX)
     files_failed = files_raw.startswith(_COMMAND_FAILED_PREFIX)
@@ -405,19 +454,21 @@ def _merge_service_states(units_raw: str, files_raw: str) -> str:
 
     rows = []
     for unit in sorted(set(running) | set(enabled)):
-        run_state = running.get(unit)
-        if run_state is None:
-            run_state = "unknown" if units_failed else "not-found"
+        load_active_sub = running.get(unit)
+        if load_active_sub is None:
+            load = "unknown" if units_failed else "not-found"
+            load_active_sub = (load, _NO_VALUE, _NO_VALUE)
+        load, active, sub = load_active_sub
+
         enable_state = enabled.get(unit)
         if enable_state is None:
             enable_state = "unknown" if files_failed else "not-found"
 
         if not units_failed and not files_failed:
-            load_state = run_state.split(" ", 1)[0]
-            if load_state == "not-found" and enable_state == "not-found":
+            if load == "not-found" and enable_state == "not-found":
                 continue
 
-        rows.append(f"{unit} {run_state} [enabled: {enable_state}]")
+        rows.append((unit, load, active, sub, enable_state))
 
     lines = []
     if units_failed:
@@ -425,8 +476,7 @@ def _merge_service_states(units_raw: str, files_raw: str) -> str:
     if files_failed:
         lines.append(f"(enabled state unavailable: {files_raw})")
     if rows:
-        lines.append("UNIT LOAD ACTIVE SUB ENABLED")
-        lines.extend(rows)
+        lines.extend(_render_service_rows(rows))
     return "\n".join(lines)
 
 

--- a/configurator/supportinfo.py
+++ b/configurator/supportinfo.py
@@ -353,8 +353,12 @@ _NO_VALUE = "-"
 # header/footer. Left in place it becomes the first whitespace-split token,
 # which shifts every following field over by one and corrupts the unit name
 # used as this row's dict key. Stripped unconditionally before parsing; a
-# normal line has nothing here to strip.
-_LEADING_GLYPH = re.compile(r"^[^\w\s]+\s+")
+# normal line has nothing here to strip. The `\s*` allows for leading
+# indentation ahead of the glyph itself -- real hardware puts the glyph at
+# column 0, but nothing about the format guarantees that, and the
+# unanchored version silently mis-parsed an indented glyph the same way
+# the unstripped glyph itself once did.
+_LEADING_GLYPH = re.compile(r"^\s*[^\w\s]+\s+")
 
 
 def _parse_list_units(raw: str) -> dict:
@@ -509,14 +513,32 @@ def _service_rows_for_scope(scope: str, units_raw: str, files_raw: str) -> tuple
 # and actively playing.
 
 
+# Conservative: a valid Linux username, nothing else. Anything that does
+# not match -- a comment, a blank line, an accidental sentence -- must
+# fall through to the linger-directory fallback rather than being used
+# verbatim as a --machine=<name>@.host target.
+_PLAYER_USERNAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_-]*$")
+
+
 def _read_hifiberry_user_file() -> str:
     """Indirection so tests can replace the filesystem lookup.
 
     /etc/hifiberry.user is a single line holding the player username, when
-    present. Root-owned, world-readable.
+    present. Root-owned, world-readable. Blank lines and "#"-prefixed
+    comments are skipped; the first remaining line is used only if it
+    looks like a real username (_PLAYER_USERNAME_RE) -- a comment-only or
+    otherwise malformed file (e.g. just "# the player user") must not
+    produce a bogus username, since that would build a broken --machine
+    target and report the user scope unavailable instead of correctly
+    falling through to the linger directory.
     """
     with open("/etc/hifiberry.user") as f:
-        return f.readline().strip()
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            return line if _PLAYER_USERNAME_RE.match(line) else ""
+    return ""
 
 
 def _list_linger_users() -> list:
@@ -533,23 +555,31 @@ def _list_linger_users() -> list:
 def _detect_player_user() -> tuple:
     """Find the username the player daemons' systemd --user instance runs as.
 
-    /etc/hifiberry.user is the primary source. Older images may not carry
-    it, so the fallback is whoever has systemd linger enabled: the player
-    user must have it (its user services could not otherwise survive a
-    reboot without an interactive login), and on a HiFiBerryOS install it
-    is normally the only lingering user. If neither source resolves to
+    /etc/hifiberry.user is the primary source and wins unconditionally when
+    it resolves to a valid name -- the linger fallback below is never even
+    consulted in that case. Older images may not carry the file (or it may
+    be empty/comment-only/malformed, see _read_hifiberry_user_file), so the
+    fallback is whoever has systemd linger enabled: the player user must
+    have it (its user services could not otherwise survive a reboot
+    without an interactive login), and on a HiFiBerryOS install it is
+    normally the only lingering user. If neither source resolves to
     exactly one name, no username is guessed -- the caller reports the
     user scope as unavailable, with the reason returned here, rather than
     silently querying the wrong account or none at all.
 
-    Returns (username, None) on success, or (None, reason) on failure.
+    Returns (username, source) on success -- source names *how* the user
+    was found (e.g. "from /etc/hifiberry.user"), not the username itself,
+    so a maintainer can audit the detection in a public bug report without
+    the report ever containing what is, on every device seen so far, a
+    person's real login name. Returns (None, reason) on failure, reason
+    being a human-readable explanation.
     """
     try:
         name = _read_hifiberry_user_file()
     except OSError:
         name = ""
     if name:
-        return name, None
+        return name, "from /etc/hifiberry.user"
 
     try:
         entries = [u for u in _list_linger_users() if not u.startswith(".")]
@@ -557,15 +587,15 @@ def _detect_player_user() -> tuple:
         entries = []
 
     if len(entries) == 1:
-        return entries[0], None
+        return entries[0], "from linger (single account)"
     if not entries:
         return None, (
             "no player user found (/etc/hifiberry.user missing and no "
             "lingering user in /var/lib/systemd/linger/)"
         )
     return None, (
-        "ambiguous player user: multiple lingering users ("
-        + ", ".join(entries) + ")"
+        f"ambiguous player user: {len(entries)} lingering users found, "
+        "none chosen"
     )
 
 
@@ -575,6 +605,27 @@ def _current_user() -> str:
         return getpass.getuser()
     except OSError:
         return ""
+
+
+def _scrub_username(text: str, player_user: str) -> str:
+    """Strip the player username back out of raw systemctl output.
+
+    `--machine=<player_user>@.host` is passed on the command line, and a
+    connection failure (unreachable machine, no such user, ...) routinely
+    echoes it straight back in stderr -- which _run() then folds into a
+    "(command failed: ...)" note. That note reaches the rendered report
+    unredacted (redact_secrets targets credentials, not usernames), so
+    without this the same real login name _detect_player_user's source
+    string was deliberately built to avoid printing could still leak
+    through a failure message. Applied to both list-units and
+    list-unit-files output for the user scope, successful or not; a
+    literal username never legitimately appears in either.
+    """
+    if not player_user:
+        return text
+    return text.replace(f"{player_user}@.host", "<player>@.host").replace(
+        player_user, "<player>"
+    )
 
 
 def _collect_user_service_rows() -> tuple:
@@ -592,27 +643,42 @@ def _collect_user_service_rows() -> tuple:
     and one explanatory note rather than raising: a report with an
     "unavailable" line and an otherwise complete system-scope section is
     far more useful than one that aborts before it can print anything.
+
+    A successful detection is also noted, naming *how* the user was found
+    (_detect_player_user's source string) rather than the username itself
+    -- so a maintainer can tell a file-based detection from a linger guess
+    and spot a wrong one, without the report ever containing what is, on
+    every device seen so far, a person's real login name.
     """
-    player_user, reason = _detect_player_user()
+    player_user, source = _detect_player_user()
     if player_user is None:
-        return [], [f"(user services unavailable: {reason})"]
+        return [], [f"(user services unavailable: {source})"]
+
+    notes = [f"(user scope: {source})"]
 
     machine = (
         [] if _current_user() == player_user
         else [f"--machine={player_user}@.host"]
     )
 
-    units_raw = _run(
-        ["systemctl", "--user"] + machine
-        + ["list-units", "--all", "--no-legend", "--no-pager"]
-        + SERVICE_PATTERNS
+    units_raw = _scrub_username(
+        _run(
+            ["systemctl", "--user"] + machine
+            + ["list-units", "--all", "--no-legend", "--no-pager"]
+            + SERVICE_PATTERNS
+        ),
+        player_user,
     )
-    files_raw = _run(
-        ["systemctl", "--user"] + machine
-        + ["list-unit-files", "--no-legend", "--no-pager"]
-        + SERVICE_PATTERNS
+    files_raw = _scrub_username(
+        _run(
+            ["systemctl", "--user"] + machine
+            + ["list-unit-files", "--no-legend", "--no-pager"]
+            + SERVICE_PATTERNS
+        ),
+        player_user,
     )
-    return _service_rows_for_scope("user", units_raw, files_raw)
+    rows, scope_notes = _service_rows_for_scope("user", units_raw, files_raw)
+    return rows, notes + scope_notes
 
 
 def collect_services() -> str:

--- a/configurator/supportinfo.py
+++ b/configurator/supportinfo.py
@@ -6,8 +6,10 @@ everything it prints passes through redact_secrets() first.
 """
 
 import argparse
+import getpass
 import json
 import logging
+import os
 import platform
 import re
 import subprocess
@@ -393,18 +395,26 @@ def _parse_list_unit_files(raw: str) -> dict:
 
 
 def _render_service_rows(rows: list) -> list:
-    """Render (unit, load, active, sub, enabled) tuples as an aligned table.
+    """Render (scope, unit, load, active, sub, enabled) tuples as an aligned table.
 
     Column widths are computed from exactly the rows being printed (post
-    suppression) plus their headers, then every UNIT/LOAD/ACTIVE/SUB cell is
-    left-padded to its column's width -- so the ENABLED column, and every
-    column before it, starts at the same character offset on every row,
-    header included. Padding is computed with plain str.ljust on the column
-    values only; the "  " separator between columns is added on top of
-    that, not folded into the width, so two adjacent equal-width columns
+    suppression) plus their headers, then every SCOPE/UNIT/LOAD/ACTIVE/SUB
+    cell is left-padded to its column's width -- so the ENABLED column, and
+    every column before it, starts at the same character offset on every
+    row, header included. Padding is computed with plain str.ljust on the
+    column values only; the "  " separator between columns is added on top
+    of that, not folded into the width, so two adjacent equal-width columns
     are never visually ambiguous.
+
+    SCOPE ("system" or "user") is its own leading column, not folded into
+    UNIT, because "system" and "user" each define units with the same
+    name (mpd.service exists, differently, in both) -- see
+    collect_services for why the two scopes are never merged by name
+    alone. Keeping scope as a column, rather than e.g. a "user/" prefix on
+    the unit name, is what lets it line up and stay scannable alongside
+    everything else.
     """
-    headers = ("UNIT", "LOAD", "ACTIVE", "SUB")
+    headers = ("SCOPE", "UNIT", "LOAD", "ACTIVE", "SUB")
     widths = [
         max(len(headers[i]), max(len(row[i]) for row in rows))
         for i in range(len(headers))
@@ -414,13 +424,15 @@ def _render_service_rows(rows: list) -> list:
         return "  ".join(value.ljust(width) for value, width in zip(values, widths))
 
     lines = [fixed_columns(headers) + "  ENABLED"]
-    for unit, load, active, sub, enabled in rows:
-        lines.append(fixed_columns((unit, load, active, sub)) + f"  [enabled: {enabled}]")
+    for scope, unit, load, active, sub, enabled in rows:
+        lines.append(
+            fixed_columns((scope, unit, load, active, sub)) + f"  [enabled: {enabled}]"
+        )
     return lines
 
 
-def _merge_service_states(units_raw: str, files_raw: str) -> str:
-    """Combine running state and enabled state into one row per unit.
+def _service_rows_for_scope(scope: str, units_raw: str, files_raw: str) -> tuple:
+    """Combine running state and enabled state into one row per unit, for one scope.
 
     `systemctl list-units` answers "is it running now"; `list-unit-files`
     answers "will it start on the next boot". A report that only carries
@@ -433,18 +445,26 @@ def _merge_service_states(units_raw: str, files_raw: str) -> str:
 
     Units that are neither installed nor enabled are dropped. SERVICE_PATTERNS
     matches every player this project supports, and most systems have only
-    one or two of them installed; a "not-found"/"not-found" row for each of
-    the rest would bury the units that actually matter under noise nobody
-    reads. This suppression only fires when *both* commands succeeded and
-    *both* agree the unit is absent -- a command failure must never be
-    read as "not installed", so a unit is kept (with "unknown" in place of
-    whichever half failed) whenever either query could not run.
+    one or two of them installed in a given scope; a "not-found"/"not-found"
+    row for each of the rest would bury the units that actually matter
+    under noise nobody reads. This suppression only fires when *both*
+    commands succeeded and *both* agree the unit is absent -- a command
+    failure must never be read as "not installed", so a unit is kept (with
+    "unknown" in place of whichever half failed) whenever either query
+    could not run.
 
     A unit missing from `list-units` (it only appeared in list-unit-files,
     e.g. a static unit with no loaded instance) still gets a full-width
     ACTIVE/SUB placeholder rather than being collapsed to a single word --
     see _render_service_rows, which needs every row to carry the same
     number of columns to align them.
+
+    Returns (rows, notes): rows are (scope, unit, load, active, sub,
+    enabled) tuples, already scope-tagged so the caller can freely combine
+    rows from multiple scopes into one table without their unit names
+    colliding; notes are 0-2 "state unavailable" strings, one per command
+    that failed, each naming this scope so a reader can tell system
+    failures from user ones when both halves are shown together.
     """
     units_failed = units_raw.startswith(_COMMAND_FAILED_PREFIX)
     files_failed = files_raw.startswith(_COMMAND_FAILED_PREFIX)
@@ -468,36 +488,168 @@ def _merge_service_states(units_raw: str, files_raw: str) -> str:
             if load == "not-found" and enable_state == "not-found":
                 continue
 
-        rows.append((unit, load, active, sub, enable_state))
+        rows.append((scope, unit, load, active, sub, enable_state))
 
-    lines = []
+    notes = []
     if units_failed:
-        lines.append(f"(running state unavailable: {units_raw})")
+        notes.append(f"({scope} running state unavailable: {units_raw})")
     if files_failed:
-        lines.append(f"(enabled state unavailable: {files_raw})")
-    if rows:
-        lines.extend(_render_service_rows(rows))
-    return "\n".join(lines)
+        notes.append(f"({scope} enabled state unavailable: {files_raw})")
+    return rows, notes
+
+
+# --- The player user's systemd --user instance --------------------------
+#
+# On HiFiBerryOS the player daemons (mpd, librespot, shairport, ...) run as
+# systemd *user* services under a dedicated, unprivileged player account --
+# not as system services. A Services section built only from `systemctl
+# list-units` (the system manager) is therefore silent for exactly the
+# reports that matter most: it shows config-server, sigmatcpserver,
+# roomeq... and not one player, even when a player is installed, enabled
+# and actively playing.
+
+
+def _read_hifiberry_user_file() -> str:
+    """Indirection so tests can replace the filesystem lookup.
+
+    /etc/hifiberry.user is a single line holding the player username, when
+    present. Root-owned, world-readable.
+    """
+    with open("/etc/hifiberry.user") as f:
+        return f.readline().strip()
+
+
+def _list_linger_users() -> list:
+    """Indirection so tests can replace the filesystem lookup.
+
+    systemd creates one file per lingering user under this directory, named
+    after the username; a lingering user's systemd --user instance keeps
+    running without an active login session, which is required for the
+    player's units to survive a reboot without anyone signing in.
+    """
+    return sorted(os.listdir("/var/lib/systemd/linger/"))
+
+
+def _detect_player_user() -> tuple:
+    """Find the username the player daemons' systemd --user instance runs as.
+
+    /etc/hifiberry.user is the primary source. Older images may not carry
+    it, so the fallback is whoever has systemd linger enabled: the player
+    user must have it (its user services could not otherwise survive a
+    reboot without an interactive login), and on a HiFiBerryOS install it
+    is normally the only lingering user. If neither source resolves to
+    exactly one name, no username is guessed -- the caller reports the
+    user scope as unavailable, with the reason returned here, rather than
+    silently querying the wrong account or none at all.
+
+    Returns (username, None) on success, or (None, reason) on failure.
+    """
+    try:
+        name = _read_hifiberry_user_file()
+    except OSError:
+        name = ""
+    if name:
+        return name, None
+
+    try:
+        entries = [u for u in _list_linger_users() if not u.startswith(".")]
+    except OSError:
+        entries = []
+
+    if len(entries) == 1:
+        return entries[0], None
+    if not entries:
+        return None, (
+            "no player user found (/etc/hifiberry.user missing and no "
+            "lingering user in /var/lib/systemd/linger/)"
+        )
+    return None, (
+        "ambiguous player user: multiple lingering users ("
+        + ", ".join(entries) + ")"
+    )
+
+
+def _current_user() -> str:
+    """Indirection so tests can replace the process-identity lookup."""
+    try:
+        return getpass.getuser()
+    except OSError:
+        return ""
+
+
+def _collect_user_service_rows() -> tuple:
+    """Player-daemon units, queried from the player user's systemd --user instance.
+
+    `systemctl --user` talks to the calling process's own session bus, so
+    it only reaches the right instance for free when config-supportinfo
+    happens to run as the player user itself. Every other case --
+    config-supportinfo run as root, or as any other account, which is the
+    common case for a diagnostic tool -- needs `--machine=<user>@.host` to
+    reach that user's instance instead of failing or silently querying the
+    wrong (or no) session.
+
+    If the player user cannot be identified at all, this returns no rows
+    and one explanatory note rather than raising: a report with an
+    "unavailable" line and an otherwise complete system-scope section is
+    far more useful than one that aborts before it can print anything.
+    """
+    player_user, reason = _detect_player_user()
+    if player_user is None:
+        return [], [f"(user services unavailable: {reason})"]
+
+    machine = (
+        [] if _current_user() == player_user
+        else [f"--machine={player_user}@.host"]
+    )
+
+    units_raw = _run(
+        ["systemctl", "--user"] + machine
+        + ["list-units", "--all", "--no-legend", "--no-pager"]
+        + SERVICE_PATTERNS
+    )
+    files_raw = _run(
+        ["systemctl", "--user"] + machine
+        + ["list-unit-files", "--no-legend", "--no-pager"]
+        + SERVICE_PATTERNS
+    )
+    return _service_rows_for_scope("user", units_raw, files_raw)
 
 
 def collect_services() -> str:
     """Running and enabled state of the audio-related systemd units.
 
-    Two systemctl calls are needed because they report different things --
-    see _merge_service_states for why they are combined into one row per
-    unit rather than kept as separate sections. Each call goes through
-    _run independently, so one failing (e.g. systemctl missing entirely)
-    still leaves the other half of the picture intact.
+    Covers both scopes that matter on HiFiBerryOS: the system scope
+    (infrastructure daemons like config-server and sigmatcpserver) and the
+    user scope the player daemons actually run in (see the module note
+    above _read_hifiberry_user_file). The two are collected, suppressed
+    (_service_rows_for_scope) and queried independently, then combined
+    into one table with an explicit SCOPE column (_render_service_rows) --
+    never merged by unit name alone, since "system" and "user" each define
+    units of the same name (mpd.service exists, differently, in both), and
+    a same-name merge could show a player as not-found while its real,
+    running user unit sits right next to it.
+
+    Each half's two systemctl calls go through _run independently, so a
+    failure anywhere -- system or user, running-state or enabled-state,
+    missing systemctl, unreachable player user -- is reported as its own
+    note and never blanks out the rest of the section.
     """
-    units_raw = _run(
+    system_units = _run(
         ["systemctl", "list-units", "--all", "--no-legend", "--no-pager"]
         + SERVICE_PATTERNS
     )
-    files_raw = _run(
+    system_files = _run(
         ["systemctl", "list-unit-files", "--no-legend", "--no-pager"]
         + SERVICE_PATTERNS
     )
-    return _merge_service_states(units_raw, files_raw)
+    system_rows, system_notes = _service_rows_for_scope("system", system_units, system_files)
+    user_rows, user_notes = _collect_user_service_rows()
+
+    rows = system_rows + user_rows
+    lines = system_notes + user_notes
+    if rows:
+        lines.extend(_render_service_rows(rows))
+    return "\n".join(lines)
 
 
 # journalctl's default output starts every line with a timestamp

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,21 @@
+hifiberry-configurator (2.15.7) stable; urgency=medium
+
+  * config-supportinfo: review fixes for the player-user Services query
+    added in 2.15.6. The table now notes how the player user was found
+    ("user scope: from /etc/hifiberry.user" or "... from linger (single
+    account)") so a wrong guess is auditable in the report -- without ever
+    printing the username itself, which is a real person's login name on
+    every device seen so far, the same reason the hostname is already
+    left out. A failure message that could otherwise echo the account
+    name back (e.g. a refused --machine= connection) is scrubbed too.
+    _read_hifiberry_user_file() now skips blank and "#"-comment lines and
+    validates the remaining username against a conservative pattern, so a
+    comment-only or malformed file falls through to the linger fallback
+    instead of producing a bogus --machine target. The leading-glyph strip
+    is anchored past leading whitespace as well as column 0.
+
+ -- HiFiBerry <support@hifiberry.com>  Fri, 07 Aug 2026 20:00:00 +0200
+
 hifiberry-configurator (2.15.6) stable; urgency=medium
 
   * config-supportinfo: query the player user's systemd --user instance for

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,20 @@
+hifiberry-configurator (2.15.5) stable; urgency=medium
+
+  * config-supportinfo: fix the readability of the merged Services section
+    added in 2.15.4. Real hardware output showed three rendering-only bugs
+    the mocked tests didn't catch: systemctl's leading status glyph on a
+    not-found unit shifted every field in that row over by one and
+    corrupted the unit name used as the row's key; a unit with no running-
+    state data (only present in `list-unit-files`) collapsed to a single
+    placeholder word instead of occupying the normal LOAD/ACTIVE/SUB
+    columns, leaving rows with different field counts; and no column was
+    actually padded, so nothing lined up. Columns are now computed from
+    the rows actually printed and padded to width, the glyph is stripped
+    before parsing, and a missing value gets an explicit "-" instead of
+    vanishing. What is collected, suppressed, and merged is unchanged.
+
+ -- HiFiBerry <support@hifiberry.com>  Fri, 07 Aug 2026 18:00:00 +0200
+
 hifiberry-configurator (2.15.4) stable; urgency=medium
 
   * config-supportinfo: report each service's enabled state (will it start

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,24 @@
+hifiberry-configurator (2.15.6) stable; urgency=medium
+
+  * config-supportinfo: query the player user's systemd --user instance for
+    the Services section, not just the system instance. On HiFiBerryOS the
+    player daemons (mpd, librespot, shairport, ...) run as systemd *user*
+    services under a dedicated account, so the system scope alone was
+    silent for exactly the reports that matter most: a real device with mpd
+    installed, enabled and playing showed no mpd at all. The player user is
+    read from /etc/hifiberry.user, falling back to the single lingering
+    user under /var/lib/systemd/linger/ on older images; querying uses
+    `systemctl --user` directly when config-supportinfo already runs as
+    that user, or `--machine=<user>@.host` otherwise (root, most commonly).
+    Both scopes render in the same table with a new SCOPE column, so a
+    same-named unit in each (mpd.service exists, differently, in both) is
+    never merged or confused with the other -- system and user units are
+    always distinct rows. A user instance that cannot be reached (no player
+    user found, connection refused, ...) is reported as unavailable with
+    the reason; it does not blank out the system half, or vice versa.
+
+ -- HiFiBerry <support@hifiberry.com>  Fri, 07 Aug 2026 19:00:00 +0200
+
 hifiberry-configurator (2.15.5) stable; urgency=medium
 
   * config-supportinfo: fix the readability of the merged Services section

--- a/man/config-supportinfo.1
+++ b/man/config-supportinfo.1
@@ -1,4 +1,4 @@
-.TH CONFIG-SUPPORTINFO 1 "August 2026" "configurator 2.15.6" "HiFiBerry Configuration Tools"
+.TH CONFIG-SUPPORTINFO 1 "August 2026" "configurator 2.15.7" "HiFiBerry Configuration Tools"
 .SH NAME
 config-supportinfo \- collect a diagnostic report for bug reports
 .SH SYNOPSIS

--- a/man/config-supportinfo.1
+++ b/man/config-supportinfo.1
@@ -1,4 +1,4 @@
-.TH CONFIG-SUPPORTINFO 1 "August 2026" "configurator 2.15.4" "HiFiBerry Configuration Tools"
+.TH CONFIG-SUPPORTINFO 1 "August 2026" "configurator 2.15.5" "HiFiBerry Configuration Tools"
 .SH NAME
 config-supportinfo \- collect a diagnostic report for bug reports
 .SH SYNOPSIS

--- a/man/config-supportinfo.1
+++ b/man/config-supportinfo.1
@@ -1,4 +1,4 @@
-.TH CONFIG-SUPPORTINFO 1 "August 2026" "configurator 2.15.5" "HiFiBerry Configuration Tools"
+.TH CONFIG-SUPPORTINFO 1 "August 2026" "configurator 2.15.6" "HiFiBerry Configuration Tools"
 .SH NAME
 config-supportinfo \- collect a diagnostic report for bug reports
 .SH SYNOPSIS
@@ -9,7 +9,8 @@ config-supportinfo \- collect a diagnostic report for bug reports
 collects hardware, package, service and error information into a single block
 of text that can be pasted into a bug report on
 https://github.com/hifiberry/hifiberry-os/issues. For each audio-related
-systemd unit, the Services section reports both whether it is running now
+systemd unit, in both the system scope and the player user's systemd
+--user scope, the Services section reports both whether it is running now
 and whether it is enabled to start on the next boot.
 .PP
 Passwords, pre-shared keys, tokens and credentials embedded in URLs are

--- a/tests/test_supportinfo_commands.py
+++ b/tests/test_supportinfo_commands.py
@@ -194,15 +194,32 @@ def test_service_patterns_cover_the_units_missing_from_the_original_list():
 
 
 def _systemctl_side_effect(units_stdout=None, units_result=None,
-                            files_stdout=None, files_result=None):
-    """subprocess.run side_effect that tells list-units and list-unit-files apart."""
+                            files_stdout=None, files_result=None,
+                            user_units_stdout=None, user_units_result=None,
+                            user_files_stdout=None, user_files_result=None):
+    """subprocess.run side_effect that tells apart all four systemctl calls
+    collect_services() can make: system/user x list-units/list-unit-files.
+
+    Scope is told apart by "--user" being present in the command; the
+    subcommand by which of "list-units"/"list-unit-files" appears in it (its
+    position shifts depending on whether --machine=... is also present).
+    """
 
     def run(cmd, **kwargs):
-        if cmd[1] == "list-units":
+        is_user = "--user" in cmd
+        if "list-units" in cmd:
+            if is_user:
+                if user_units_result is not None:
+                    return user_units_result
+                return _completed(user_units_stdout or "")
             if units_result is not None:
                 return units_result
             return _completed(units_stdout or "")
-        assert cmd[1] == "list-unit-files"
+        assert "list-unit-files" in cmd
+        if is_user:
+            if user_files_result is not None:
+                return user_files_result
+            return _completed(user_files_stdout or "")
         if files_result is not None:
             return files_result
         return _completed(files_stdout or "")
@@ -210,8 +227,47 @@ def _systemctl_side_effect(units_stdout=None, units_result=None,
     return run
 
 
+def _disable_user_scope():
+    """Patch out the user-scope query entirely.
+
+    Used by tests that are only exercising the system scope: without this,
+    those tests would depend on whether the machine actually running them
+    has /etc/hifiberry.user or a lingering user -- true on a HiFiBerryOS
+    device, false (deterministically) on a dev machine or CI runner, but a
+    dependency on real filesystem state that a unit test should not have
+    either way.
+    """
+    return patch.object(
+        supportinfo, "_detect_player_user", return_value=(None, "disabled for test")
+    )
+
+
+def _columns(line: str) -> list:
+    """Split a rendered row on its column boundaries (runs of 2+ spaces)."""
+    return re.split(r" {2,}", line.rstrip())
+
+
+def _header_and_rows(result: str) -> tuple:
+    """Split rendered output into (header, [data rows]), skipping any
+    "(... unavailable: ...)" notes -- those are prose, not table rows, and
+    are not expected to share the table's column count or alignment.
+    """
+    lines = [l for l in result.splitlines() if not l.startswith("(")]
+    header = next(l for l in lines if l.startswith("SCOPE"))
+    rows = [l for l in lines if l != header]
+    return header, rows
+
+
+def _row_for(result: str, unit: str):
+    """The single rendered row whose UNIT column is exactly `unit`."""
+    _, rows = _header_and_rows(result)
+    matches = [r for r in rows if _columns(r)[1] == unit]
+    assert len(matches) == 1, f"expected exactly one row for {unit!r}, got: {matches}"
+    return matches[0]
+
+
 def test_collect_services_queries_both_list_units_and_list_unit_files():
-    with patch(
+    with _disable_user_scope(), patch(
         "subprocess.run", side_effect=_systemctl_side_effect()
     ) as run:
         supportinfo.collect_services()
@@ -235,7 +291,7 @@ def test_collect_services_queries_both_list_units_and_list_unit_files():
 
 
 def test_collect_services_merges_running_and_enabled_state_in_one_row():
-    with patch(
+    with _disable_user_scope(), patch(
         "subprocess.run",
         side_effect=_systemctl_side_effect(
             units_stdout="mpd.service loaded active running Music Player Daemon",
@@ -243,17 +299,15 @@ def test_collect_services_merges_running_and_enabled_state_in_one_row():
         ),
     ):
         result = supportinfo.collect_services()
-    lines = [l for l in result.splitlines() if l.startswith("mpd.service")]
-    assert len(lines) == 1
-    line = lines[0]
+    line = _row_for(result, "mpd.service")
     assert "loaded" in line and "active" in line and "running" in line
-    assert "enabled" in line
+    assert "enabled: enabled" in line
 
 
 def test_collect_services_shows_an_enabled_but_not_running_unit():
     # Real diagnostic situation: the unit will start on the next boot but
     # is not running right now (crashed, never started this session, ...).
-    with patch(
+    with _disable_user_scope(), patch(
         "subprocess.run",
         side_effect=_systemctl_side_effect(
             units_stdout="shairport-sync.service loaded inactive dead",
@@ -261,7 +315,7 @@ def test_collect_services_shows_an_enabled_but_not_running_unit():
         ),
     ):
         result = supportinfo.collect_services()
-    line = next(l for l in result.splitlines() if l.startswith("shairport-sync.service"))
+    line = _row_for(result, "shairport-sync.service")
     assert "inactive" in line
     assert "enabled: enabled" in line
 
@@ -269,7 +323,7 @@ def test_collect_services_shows_an_enabled_but_not_running_unit():
 def test_collect_services_shows_a_running_but_disabled_unit():
     # Real diagnostic situation: works today, will not come back after a
     # reboot -- exactly the report this feature exists to settle.
-    with patch(
+    with _disable_user_scope(), patch(
         "subprocess.run",
         side_effect=_systemctl_side_effect(
             units_stdout="mpd.service loaded active running",
@@ -277,7 +331,7 @@ def test_collect_services_shows_a_running_but_disabled_unit():
         ),
     ):
         result = supportinfo.collect_services()
-    line = next(l for l in result.splitlines() if l.startswith("mpd.service"))
+    line = _row_for(result, "mpd.service")
     assert "active" in line and "running" in line
     assert "enabled: disabled" in line
 
@@ -286,7 +340,7 @@ def test_collect_services_drops_units_neither_installed_nor_enabled():
     # squeezelite is a SERVICE_PATTERNS entry but is not installed on most
     # systems -- systemctl reports it "not-found" in both calls, and that
     # combination must not survive into the report as noise.
-    with patch(
+    with _disable_user_scope(), patch(
         "subprocess.run",
         side_effect=_systemctl_side_effect(
             units_stdout=(
@@ -305,7 +359,7 @@ def test_collect_services_keeps_running_state_when_list_unit_files_fails():
     # _run() reports failures as strings rather than raising; a missing or
     # failing systemctl on one call must not blank out the other half of
     # the report.
-    with patch(
+    with _disable_user_scope(), patch(
         "subprocess.run",
         side_effect=_systemctl_side_effect(
             units_stdout="mpd.service loaded active running",
@@ -316,11 +370,11 @@ def test_collect_services_keeps_running_state_when_list_unit_files_fails():
     assert "mpd.service" in result
     assert "active" in result and "running" in result
     assert "enabled: unknown" in result
-    assert "enabled state unavailable" in result
+    assert "system enabled state unavailable" in result
 
 
 def test_collect_services_keeps_enabled_state_when_list_units_fails():
-    with patch(
+    with _disable_user_scope(), patch(
         "subprocess.run",
         side_effect=_systemctl_side_effect(
             units_result=_failed("Failed to list units: access denied"),
@@ -331,18 +385,19 @@ def test_collect_services_keeps_enabled_state_when_list_units_fails():
     assert "mpd.service" in result
     assert "enabled: enabled" in result
     assert "unknown" in result
-    assert "running state unavailable" in result
+    assert "system running state unavailable" in result
 
 
-def test_merge_service_states_never_treats_a_failure_as_not_found():
-    # Direct check on the merge function: even if both calls fail, no unit
-    # can be reported as "not-found" from that -- there is simply no data.
-    result = supportinfo._merge_service_states(
-        "(command failed: no systemctl)", "(command failed: no systemctl)"
+def test_service_rows_for_scope_never_treats_a_failure_as_not_found():
+    # Direct check on the per-scope merge function: even if both calls
+    # fail, no unit can be reported as "not-found" from that -- there is
+    # simply no data.
+    rows, notes = supportinfo._service_rows_for_scope(
+        "system", "(command failed: no systemctl)", "(command failed: no systemctl)"
     )
-    assert "not-found" not in result
-    assert "running state unavailable" in result
-    assert "enabled state unavailable" in result
+    assert rows == []
+    assert any("running state unavailable" in n for n in notes)
+    assert any("enabled state unavailable" in n for n in notes)
 
 
 # --- Rendering: alignment, glyph stripping, column placeholders ---------
@@ -357,10 +412,6 @@ def test_merge_service_states_never_treats_a_failure_as_not_found():
 # so they keep catching a regression without breaking on the next
 # unrelated wording change.
 
-def _columns(line: str) -> list:
-    """Split a rendered row on its column boundaries (runs of 2+ spaces)."""
-    return re.split(r" {2,}", line.rstrip())
-
 
 def test_collect_services_rows_share_the_same_column_count_as_the_header():
     units_stdout = "\n".join([
@@ -373,16 +424,17 @@ def test_collect_services_rows_share_the_same_column_count_as_the_header():
         "sambamount.service enabled enabled",
         "hifiberry-raat.service static enabled",
     ])
-    with patch(
+    with _disable_user_scope(), patch(
         "subprocess.run",
         side_effect=_systemctl_side_effect(units_stdout=units_stdout, files_stdout=files_stdout),
     ):
         result = supportinfo.collect_services()
 
-    lines = result.splitlines()
-    assert len(lines) > 1  # a header plus at least one row
-    column_counts = {len(_columns(line)) for line in lines}
-    assert len(column_counts) == 1, f"ragged columns: {lines}"
+    header, rows = _header_and_rows(result)
+    table_lines = [header] + rows
+    assert len(table_lines) > 1  # a header plus at least one row
+    column_counts = {len(_columns(line)) for line in table_lines}
+    assert len(column_counts) == 1, f"ragged columns: {table_lines}"
 
 
 def test_collect_services_enabled_column_starts_at_the_same_offset_on_every_row():
@@ -395,21 +447,24 @@ def test_collect_services_enabled_column_starts_at_the_same_offset_on_every_row(
         "sambamount.service enabled enabled",
         "hifiberry-raat.service static enabled",
     ])
-    with patch(
+    with _disable_user_scope(), patch(
         "subprocess.run",
         side_effect=_systemctl_side_effect(units_stdout=units_stdout, files_stdout=files_stdout),
     ):
         result = supportinfo.collect_services()
 
-    header, *rows = result.splitlines()
-    enabled_offsets = {line.index("ENABLED" if line is header else "[enabled:") for line in [header] + rows}
+    header, rows = _header_and_rows(result)
+    enabled_offsets = {
+        line.index("ENABLED" if line is header else "[enabled:")
+        for line in [header] + rows
+    }
     assert len(enabled_offsets) == 1, f"misaligned ENABLED column: {result}"
 
 
 def test_collect_services_strips_the_systemctl_status_glyph():
     units_stdout = "● shairport-sync.service not-found inactive dead"
     files_stdout = "shairport-sync.service enabled enabled"
-    with patch(
+    with _disable_user_scope(), patch(
         "subprocess.run",
         side_effect=_systemctl_side_effect(units_stdout=units_stdout, files_stdout=files_stdout),
     ):
@@ -417,7 +472,7 @@ def test_collect_services_strips_the_systemctl_status_glyph():
 
     assert "●" not in result  # "●"
     # The glyph must not have swallowed the unit name into the LOAD field.
-    line = next(l for l in result.splitlines() if l.startswith("shairport-sync.service"))
+    line = _row_for(result, "shairport-sync.service")
     assert "not-found" in line
     assert "enabled: enabled" in line
 
@@ -432,16 +487,15 @@ def test_collect_services_unit_missing_running_state_still_occupies_its_columns(
         "mpd.service enabled enabled",
         "hifiberry-raat.service static enabled",
     ])
-    with patch(
+    with _disable_user_scope(), patch(
         "subprocess.run",
         side_effect=_systemctl_side_effect(units_stdout=units_stdout, files_stdout=files_stdout),
     ):
         result = supportinfo.collect_services()
 
-    lines = result.splitlines()
-    header, *rows = lines
-    raat_line = next(l for l in rows if l.startswith("hifiberry-raat.service"))
-    mpd_line = next(l for l in rows if l.startswith("mpd.service"))
+    header, _ = _header_and_rows(result)
+    raat_line = _row_for(result, "hifiberry-raat.service")
+    mpd_line = _row_for(result, "mpd.service")
 
     assert len(_columns(raat_line)) == len(_columns(header))
     assert len(_columns(raat_line)) == len(_columns(mpd_line))
@@ -449,3 +503,208 @@ def test_collect_services_unit_missing_running_state_still_occupies_its_columns(
     assert "not-found" in columns  # LOAD: no running-state entry
     assert columns.count("-") == 2  # ACTIVE and SUB: explicit placeholders
     assert "enabled: static" in raat_line
+
+
+# --- The player user's systemd --user instance ---------------------------
+#
+# On HiFiBerryOS the player daemons run as systemd *user* services under a
+# dedicated account, not as system services -- the system scope alone is
+# silent for exactly the reports that matter most (a player bug). These
+# tests cover: finding that account (primary source, fallback, neither
+# available), choosing --user vs --machine=<user>@.host depending on who
+# config-supportinfo itself runs as, keeping the two scopes from colliding
+# on a shared unit name, an unreachable user instance not being fatal to
+# the system half, and the alignment property holding once both scopes are
+# mixed into the same table.
+
+
+def test_detect_player_user_reads_the_hifiberry_user_file():
+    with patch.object(supportinfo, "_read_hifiberry_user_file", return_value="matuschd"):
+        user, reason = supportinfo._detect_player_user()
+    assert user == "matuschd"
+    assert reason is None
+
+
+def test_detect_player_user_falls_back_to_the_linger_directory():
+    # Older images may not carry /etc/hifiberry.user; the player user must
+    # have systemd linger enabled regardless (its services could not
+    # otherwise survive a reboot without an interactive login), so a
+    # single lingering user is the next best signal.
+    with patch.object(supportinfo, "_read_hifiberry_user_file", side_effect=OSError("no such file")), \
+         patch.object(supportinfo, "_list_linger_users", return_value=["matuschd"]):
+        user, reason = supportinfo._detect_player_user()
+    assert user == "matuschd"
+    assert reason is None
+
+
+def test_detect_player_user_reports_unavailable_when_neither_source_resolves():
+    with patch.object(supportinfo, "_read_hifiberry_user_file", side_effect=OSError("no such file")), \
+         patch.object(supportinfo, "_list_linger_users", side_effect=OSError("no such directory")):
+        user, reason = supportinfo._detect_player_user()
+    assert user is None
+    assert reason  # a human-readable explanation, not silence
+    assert "no player user" in reason
+
+
+def test_detect_player_user_reports_unavailable_when_linger_is_ambiguous():
+    # More than one lingering user and no /etc/hifiberry.user to break the
+    # tie: guessing which one runs the players would risk querying the
+    # wrong (or an innocent bystander's) session, so this is unavailable
+    # too, not a coin flip.
+    with patch.object(supportinfo, "_read_hifiberry_user_file", side_effect=OSError("no such file")), \
+         patch.object(supportinfo, "_list_linger_users", return_value=["alice", "bob"]):
+        user, reason = supportinfo._detect_player_user()
+    assert user is None
+    assert "ambiguous" in reason
+
+
+def test_collect_user_services_uses_plain_user_flag_when_already_that_user():
+    with patch.object(supportinfo, "_detect_player_user", return_value=("matuschd", None)), \
+         patch.object(supportinfo, "_current_user", return_value="matuschd"), \
+         patch("subprocess.run", side_effect=_systemctl_side_effect(
+             user_units_stdout="mpd.service loaded active running",
+             user_files_stdout="mpd.service enabled enabled",
+         )) as run:
+        supportinfo._collect_user_service_rows()
+
+    commands = [call.args[0] for call in run.call_args_list]
+    assert len(commands) == 2
+    for cmd in commands:
+        assert cmd[0] == "systemctl"
+        assert "--user" in cmd
+        assert not any(arg.startswith("--machine=") for arg in cmd)
+
+
+def test_collect_user_services_uses_machine_flag_when_a_different_user():
+    with patch.object(supportinfo, "_detect_player_user", return_value=("matuschd", None)), \
+         patch.object(supportinfo, "_current_user", return_value="root"), \
+         patch("subprocess.run", side_effect=_systemctl_side_effect(
+             user_units_stdout="mpd.service loaded active running",
+             user_files_stdout="mpd.service enabled enabled",
+         )) as run:
+        supportinfo._collect_user_service_rows()
+
+    commands = [call.args[0] for call in run.call_args_list]
+    assert len(commands) == 2
+    for cmd in commands:
+        assert cmd[0] == "systemctl"
+        assert "--user" in cmd
+        assert "--machine=matuschd@.host" in cmd
+
+
+def test_collect_services_distinguishes_same_named_units_by_scope():
+    # The name-collision case the coordinator flagged: a system-scope
+    # mpd.service that doesn't exist, and a user-scope mpd.service that is
+    # installed, enabled and running. Both must render, distinctly, rather
+    # than one clobbering the other.
+    with patch.object(supportinfo, "_detect_player_user", return_value=("matuschd", None)), \
+         patch.object(supportinfo, "_current_user", return_value="root"), \
+         patch("subprocess.run", side_effect=_systemctl_side_effect(
+             units_stdout="● mpd.service not-found inactive dead",
+             files_stdout="",
+             user_units_stdout="mpd.service loaded active running",
+             user_files_stdout="mpd.service enabled enabled",
+         )):
+        result = supportinfo.collect_services()
+
+    header, *rows = result.splitlines()
+    mpd_rows = [r for r in rows if _columns(r)[1] == "mpd.service"]
+    # The system-scope not-found/not-found mpd.service is suppressed as
+    # noise (same rule as before); only the real, running user unit shows.
+    assert len(mpd_rows) == 1
+    scope, unit, load, active, sub = _columns(mpd_rows[0])[:5]
+    assert scope == "user"
+    assert active == "active" and sub == "running"
+    assert "enabled: enabled" in mpd_rows[0]
+
+
+def test_collect_services_shows_both_scopes_of_a_genuinely_colliding_unit():
+    # Same unit name present -- and *not* suppressed -- in both scopes at
+    # once: both rows must survive, tagged distinctly, never merged.
+    with patch.object(supportinfo, "_detect_player_user", return_value=("matuschd", None)), \
+         patch.object(supportinfo, "_current_user", return_value="root"), \
+         patch("subprocess.run", side_effect=_systemctl_side_effect(
+             units_stdout="mpd.service loaded active running",
+             files_stdout="mpd.service enabled enabled",
+             user_units_stdout="mpd.service loaded active running",
+             user_files_stdout="mpd.service enabled enabled",
+         )):
+        result = supportinfo.collect_services()
+
+    header, *rows = result.splitlines()
+    mpd_rows = [r for r in rows if _columns(r)[1] == "mpd.service"]
+    assert len(mpd_rows) == 2
+    scopes = {_columns(r)[0] for r in mpd_rows}
+    assert scopes == {"system", "user"}
+
+
+def test_collect_services_reports_unreachable_user_instance_without_dropping_the_system_half():
+    with patch.object(supportinfo, "_detect_player_user", return_value=("matuschd", None)), \
+         patch.object(supportinfo, "_current_user", return_value="root"), \
+         patch("subprocess.run", side_effect=_systemctl_side_effect(
+             units_stdout="config-server.service loaded active running",
+             files_stdout="config-server.service enabled enabled",
+             user_units_result=_failed("Failed to connect to bus: Host is down"),
+             user_files_result=_failed("Failed to connect to bus: Host is down"),
+         )):
+        result = supportinfo.collect_services()
+
+    assert "config-server.service" in result
+    assert _row_for(result, "config-server.service")
+    assert "user running state unavailable" in result
+    assert "user enabled state unavailable" in result
+    assert "Host is down" in result
+
+
+def test_collect_services_reports_missing_player_user_without_being_fatal():
+    with patch.object(
+        supportinfo, "_detect_player_user",
+        return_value=(None, "no player user found (test)"),
+    ), patch(
+        "subprocess.run",
+        side_effect=_systemctl_side_effect(
+            units_stdout="config-server.service loaded active running",
+            files_stdout="config-server.service enabled enabled",
+        ),
+    ):
+        result = supportinfo.collect_services()
+
+    assert "config-server.service" in result
+    assert "user services unavailable" in result
+    assert "no player user found (test)" in result
+
+
+def test_collect_services_alignment_holds_across_mixed_scope_rows():
+    with patch.object(supportinfo, "_detect_player_user", return_value=("matuschd", None)), \
+         patch.object(supportinfo, "_current_user", return_value="root"), \
+         patch("subprocess.run", side_effect=_systemctl_side_effect(
+             units_stdout="\n".join([
+                 "config-server.service loaded active running",
+                 "sigmatcpserver.service loaded active running",
+             ]),
+             files_stdout="\n".join([
+                 "config-server.service enabled enabled",
+                 "sigmatcpserver.service enabled enabled",
+             ]),
+             user_units_stdout="\n".join([
+                 "mpd.service loaded active running",
+                 "librespot.service loaded active running",
+                 "shairport.service loaded inactive dead",
+             ]),
+             user_files_stdout="\n".join([
+                 "mpd.service enabled enabled",
+                 "librespot.service enabled enabled",
+                 "shairport.service enabled enabled",
+             ]),
+         )):
+        result = supportinfo.collect_services()
+
+    lines = result.splitlines()
+    assert len(lines) == 6  # header + 2 system rows + 3 user rows
+    column_counts = {len(_columns(line)) for line in lines}
+    assert len(column_counts) == 1, f"ragged columns: {lines}"
+    header, *rows = lines
+    enabled_offsets = {line.index("ENABLED" if line is header else "[enabled:") for line in lines}
+    assert len(enabled_offsets) == 1, f"misaligned ENABLED column: {result}"
+    scopes = {_columns(r)[0] for r in rows}
+    assert scopes == {"system", "user"}

--- a/tests/test_supportinfo_commands.py
+++ b/tests/test_supportinfo_commands.py
@@ -1,3 +1,4 @@
+import re
 import subprocess
 from unittest.mock import patch
 
@@ -342,3 +343,109 @@ def test_merge_service_states_never_treats_a_failure_as_not_found():
     assert "not-found" not in result
     assert "running state unavailable" in result
     assert "enabled state unavailable" in result
+
+
+# --- Rendering: alignment, glyph stripping, column placeholders ---------
+#
+# Real hardware output surfaced three rendering-only bugs the mocked tests
+# above never exercised: systemctl's leading "●" glyph on a not-found unit
+# shifted every field in that row over by one; a unit that only appeared
+# in list-unit-files (never in list-units) collapsed its running-state
+# placeholder to a single word instead of occupying the normal three
+# columns; and nothing was actually padded, so columns did not line up.
+# These tests assert the alignment *property* -- not a golden string --
+# so they keep catching a regression without breaking on the next
+# unrelated wording change.
+
+def _columns(line: str) -> list:
+    """Split a rendered row on its column boundaries (runs of 2+ spaces)."""
+    return re.split(r" {2,}", line.rstrip())
+
+
+def test_collect_services_rows_share_the_same_column_count_as_the_header():
+    units_stdout = "\n".join([
+        "mpd.service loaded active running Music Player Daemon",
+        "sambamount.service loaded active exited Samba Mount",
+        "● shairport-sync.service not-found inactive dead",
+    ])
+    files_stdout = "\n".join([
+        "mpd.service disabled disabled",
+        "sambamount.service enabled enabled",
+        "hifiberry-raat.service static enabled",
+    ])
+    with patch(
+        "subprocess.run",
+        side_effect=_systemctl_side_effect(units_stdout=units_stdout, files_stdout=files_stdout),
+    ):
+        result = supportinfo.collect_services()
+
+    lines = result.splitlines()
+    assert len(lines) > 1  # a header plus at least one row
+    column_counts = {len(_columns(line)) for line in lines}
+    assert len(column_counts) == 1, f"ragged columns: {lines}"
+
+
+def test_collect_services_enabled_column_starts_at_the_same_offset_on_every_row():
+    units_stdout = "\n".join([
+        "mpd.service loaded active running",
+        "sambamount.service loaded active exited",
+    ])
+    files_stdout = "\n".join([
+        "mpd.service disabled disabled",
+        "sambamount.service enabled enabled",
+        "hifiberry-raat.service static enabled",
+    ])
+    with patch(
+        "subprocess.run",
+        side_effect=_systemctl_side_effect(units_stdout=units_stdout, files_stdout=files_stdout),
+    ):
+        result = supportinfo.collect_services()
+
+    header, *rows = result.splitlines()
+    enabled_offsets = {line.index("ENABLED" if line is header else "[enabled:") for line in [header] + rows}
+    assert len(enabled_offsets) == 1, f"misaligned ENABLED column: {result}"
+
+
+def test_collect_services_strips_the_systemctl_status_glyph():
+    units_stdout = "● shairport-sync.service not-found inactive dead"
+    files_stdout = "shairport-sync.service enabled enabled"
+    with patch(
+        "subprocess.run",
+        side_effect=_systemctl_side_effect(units_stdout=units_stdout, files_stdout=files_stdout),
+    ):
+        result = supportinfo.collect_services()
+
+    assert "●" not in result  # "●"
+    # The glyph must not have swallowed the unit name into the LOAD field.
+    line = next(l for l in result.splitlines() if l.startswith("shairport-sync.service"))
+    assert "not-found" in line
+    assert "enabled: enabled" in line
+
+
+def test_collect_services_unit_missing_running_state_still_occupies_its_columns():
+    # hifiberry-raat.service only appears in list-unit-files (a static unit
+    # with no loaded instance) -- it must still render the same number of
+    # columns as a unit with full running-state data, with an explicit
+    # placeholder rather than a collapsed/missing field.
+    units_stdout = "mpd.service loaded active running"
+    files_stdout = "\n".join([
+        "mpd.service enabled enabled",
+        "hifiberry-raat.service static enabled",
+    ])
+    with patch(
+        "subprocess.run",
+        side_effect=_systemctl_side_effect(units_stdout=units_stdout, files_stdout=files_stdout),
+    ):
+        result = supportinfo.collect_services()
+
+    lines = result.splitlines()
+    header, *rows = lines
+    raat_line = next(l for l in rows if l.startswith("hifiberry-raat.service"))
+    mpd_line = next(l for l in rows if l.startswith("mpd.service"))
+
+    assert len(_columns(raat_line)) == len(_columns(header))
+    assert len(_columns(raat_line)) == len(_columns(mpd_line))
+    columns = _columns(raat_line)
+    assert "not-found" in columns  # LOAD: no running-state entry
+    assert columns.count("-") == 2  # ACTIVE and SUB: explicit placeholders
+    assert "enabled: static" in raat_line

--- a/tests/test_supportinfo_commands.py
+++ b/tests/test_supportinfo_commands.py
@@ -477,6 +477,23 @@ def test_collect_services_strips_the_systemctl_status_glyph():
     assert "enabled: enabled" in line
 
 
+def test_collect_services_strips_a_status_glyph_with_leading_whitespace():
+    # Same bug class as the unanchored-past-whitespace case: real hardware
+    # puts the glyph at column 0, but the parser must not depend on that.
+    units_stdout = "  ● shairport-sync.service not-found inactive dead"
+    files_stdout = "shairport-sync.service enabled enabled"
+    with _disable_user_scope(), patch(
+        "subprocess.run",
+        side_effect=_systemctl_side_effect(units_stdout=units_stdout, files_stdout=files_stdout),
+    ):
+        result = supportinfo.collect_services()
+
+    assert "●" not in result
+    line = _row_for(result, "shairport-sync.service")
+    assert "not-found" in line
+    assert "enabled: enabled" in line
+
+
 def test_collect_services_unit_missing_running_state_still_occupies_its_columns():
     # hifiberry-raat.service only appears in list-unit-files (a static unit
     # with no loaded instance) -- it must still render the same number of
@@ -520,9 +537,11 @@ def test_collect_services_unit_missing_running_state_still_occupies_its_columns(
 
 def test_detect_player_user_reads_the_hifiberry_user_file():
     with patch.object(supportinfo, "_read_hifiberry_user_file", return_value="matuschd"):
-        user, reason = supportinfo._detect_player_user()
+        user, source = supportinfo._detect_player_user()
     assert user == "matuschd"
-    assert reason is None
+    # The source names *how* detection happened, not the username -- see
+    # the privacy tests below.
+    assert source == "from /etc/hifiberry.user"
 
 
 def test_detect_player_user_falls_back_to_the_linger_directory():
@@ -532,9 +551,9 @@ def test_detect_player_user_falls_back_to_the_linger_directory():
     # single lingering user is the next best signal.
     with patch.object(supportinfo, "_read_hifiberry_user_file", side_effect=OSError("no such file")), \
          patch.object(supportinfo, "_list_linger_users", return_value=["matuschd"]):
-        user, reason = supportinfo._detect_player_user()
+        user, source = supportinfo._detect_player_user()
     assert user == "matuschd"
-    assert reason is None
+    assert source == "from linger (single account)"
 
 
 def test_detect_player_user_reports_unavailable_when_neither_source_resolves():
@@ -556,10 +575,48 @@ def test_detect_player_user_reports_unavailable_when_linger_is_ambiguous():
         user, reason = supportinfo._detect_player_user()
     assert user is None
     assert "ambiguous" in reason
+    # The candidate names themselves must not leak into the report either.
+    assert "alice" not in reason and "bob" not in reason
+
+
+def test_read_hifiberry_user_file_skips_blank_and_comment_lines():
+    fake_lines = ["# the player user\n", "\n", "matuschd\n"]
+    with patch("builtins.open", create=True) as mock_open:
+        mock_open.return_value.__enter__.return_value = fake_lines
+        name = supportinfo._read_hifiberry_user_file()
+    assert name == "matuschd"
+
+
+def test_read_hifiberry_user_file_falls_through_on_a_comment_only_file():
+    # Real bug: a comment-only file used to return "# the player user"
+    # verbatim as the username, producing a bogus --machine target and an
+    # unavailable user scope instead of correctly falling through to the
+    # linger directory.
+    fake_lines = ["# the player user\n", "\n"]
+    with patch("builtins.open", create=True) as mock_open:
+        mock_open.return_value.__enter__.return_value = fake_lines
+        name = supportinfo._read_hifiberry_user_file()
+    assert name == ""
+
+
+def test_read_hifiberry_user_file_falls_through_on_an_invalid_username():
+    fake_lines = ["this is not a username\n"]
+    with patch("builtins.open", create=True) as mock_open:
+        mock_open.return_value.__enter__.return_value = fake_lines
+        name = supportinfo._read_hifiberry_user_file()
+    assert name == ""
+
+
+def test_detect_player_user_falls_back_to_linger_on_a_comment_only_file():
+    with patch.object(supportinfo, "_read_hifiberry_user_file", return_value=""), \
+         patch.object(supportinfo, "_list_linger_users", return_value=["matuschd"]):
+        user, source = supportinfo._detect_player_user()
+    assert user == "matuschd"
+    assert source == "from linger (single account)"
 
 
 def test_collect_user_services_uses_plain_user_flag_when_already_that_user():
-    with patch.object(supportinfo, "_detect_player_user", return_value=("matuschd", None)), \
+    with patch.object(supportinfo, "_detect_player_user", return_value=("matuschd", "from /etc/hifiberry.user")), \
          patch.object(supportinfo, "_current_user", return_value="matuschd"), \
          patch("subprocess.run", side_effect=_systemctl_side_effect(
              user_units_stdout="mpd.service loaded active running",
@@ -576,7 +633,7 @@ def test_collect_user_services_uses_plain_user_flag_when_already_that_user():
 
 
 def test_collect_user_services_uses_machine_flag_when_a_different_user():
-    with patch.object(supportinfo, "_detect_player_user", return_value=("matuschd", None)), \
+    with patch.object(supportinfo, "_detect_player_user", return_value=("matuschd", "from /etc/hifiberry.user")), \
          patch.object(supportinfo, "_current_user", return_value="root"), \
          patch("subprocess.run", side_effect=_systemctl_side_effect(
              user_units_stdout="mpd.service loaded active running",
@@ -597,7 +654,7 @@ def test_collect_services_distinguishes_same_named_units_by_scope():
     # mpd.service that doesn't exist, and a user-scope mpd.service that is
     # installed, enabled and running. Both must render, distinctly, rather
     # than one clobbering the other.
-    with patch.object(supportinfo, "_detect_player_user", return_value=("matuschd", None)), \
+    with patch.object(supportinfo, "_detect_player_user", return_value=("matuschd", "from /etc/hifiberry.user")), \
          patch.object(supportinfo, "_current_user", return_value="root"), \
          patch("subprocess.run", side_effect=_systemctl_side_effect(
              units_stdout="● mpd.service not-found inactive dead",
@@ -607,7 +664,7 @@ def test_collect_services_distinguishes_same_named_units_by_scope():
          )):
         result = supportinfo.collect_services()
 
-    header, *rows = result.splitlines()
+    _, rows = _header_and_rows(result)
     mpd_rows = [r for r in rows if _columns(r)[1] == "mpd.service"]
     # The system-scope not-found/not-found mpd.service is suppressed as
     # noise (same rule as before); only the real, running user unit shows.
@@ -621,7 +678,7 @@ def test_collect_services_distinguishes_same_named_units_by_scope():
 def test_collect_services_shows_both_scopes_of_a_genuinely_colliding_unit():
     # Same unit name present -- and *not* suppressed -- in both scopes at
     # once: both rows must survive, tagged distinctly, never merged.
-    with patch.object(supportinfo, "_detect_player_user", return_value=("matuschd", None)), \
+    with patch.object(supportinfo, "_detect_player_user", return_value=("matuschd", "from /etc/hifiberry.user")), \
          patch.object(supportinfo, "_current_user", return_value="root"), \
          patch("subprocess.run", side_effect=_systemctl_side_effect(
              units_stdout="mpd.service loaded active running",
@@ -631,7 +688,7 @@ def test_collect_services_shows_both_scopes_of_a_genuinely_colliding_unit():
          )):
         result = supportinfo.collect_services()
 
-    header, *rows = result.splitlines()
+    _, rows = _header_and_rows(result)
     mpd_rows = [r for r in rows if _columns(r)[1] == "mpd.service"]
     assert len(mpd_rows) == 2
     scopes = {_columns(r)[0] for r in mpd_rows}
@@ -639,7 +696,7 @@ def test_collect_services_shows_both_scopes_of_a_genuinely_colliding_unit():
 
 
 def test_collect_services_reports_unreachable_user_instance_without_dropping_the_system_half():
-    with patch.object(supportinfo, "_detect_player_user", return_value=("matuschd", None)), \
+    with patch.object(supportinfo, "_detect_player_user", return_value=("matuschd", "from /etc/hifiberry.user")), \
          patch.object(supportinfo, "_current_user", return_value="root"), \
          patch("subprocess.run", side_effect=_systemctl_side_effect(
              units_stdout="config-server.service loaded active running",
@@ -675,7 +732,7 @@ def test_collect_services_reports_missing_player_user_without_being_fatal():
 
 
 def test_collect_services_alignment_holds_across_mixed_scope_rows():
-    with patch.object(supportinfo, "_detect_player_user", return_value=("matuschd", None)), \
+    with patch.object(supportinfo, "_detect_player_user", return_value=("matuschd", "from /etc/hifiberry.user")), \
          patch.object(supportinfo, "_current_user", return_value="root"), \
          patch("subprocess.run", side_effect=_systemctl_side_effect(
              units_stdout="\n".join([
@@ -699,12 +756,114 @@ def test_collect_services_alignment_holds_across_mixed_scope_rows():
          )):
         result = supportinfo.collect_services()
 
-    lines = result.splitlines()
-    assert len(lines) == 6  # header + 2 system rows + 3 user rows
-    column_counts = {len(_columns(line)) for line in lines}
-    assert len(column_counts) == 1, f"ragged columns: {lines}"
-    header, *rows = lines
-    enabled_offsets = {line.index("ENABLED" if line is header else "[enabled:") for line in lines}
+    header, rows = _header_and_rows(result)
+    assert len(rows) == 5  # 2 system rows + 3 user rows
+    table_lines = [header] + rows
+    column_counts = {len(_columns(line)) for line in table_lines}
+    assert len(column_counts) == 1, f"ragged columns: {table_lines}"
+    enabled_offsets = {
+        line.index("ENABLED" if line is header else "[enabled:")
+        for line in table_lines
+    }
     assert len(enabled_offsets) == 1, f"misaligned ENABLED column: {result}"
     scopes = {_columns(r)[0] for r in rows}
     assert scopes == {"system", "user"}
+    # And the note above the table names the detection source, not the
+    # account itself.
+    assert "(user scope: from /etc/hifiberry.user)" in result
+    assert "matuschd" not in result
+
+
+# --- Privacy: the detection is auditable, the username is not ----------
+#
+# A reviewer noted the report never said which account got queried, so a
+# wrong guess would be undetectable -- but the username itself must never
+# appear either: it is a real person's login name on every device seen so
+# far, the same reason the hostname is already left out, and this report
+# is meant to be pasted into a public issue. The fix names the *source* of
+# the detection (which file/heuristic found it), not its result.
+
+
+def test_collect_services_notes_the_file_detection_source():
+    with patch.object(supportinfo, "_detect_player_user", return_value=("realname", "from /etc/hifiberry.user")), \
+         patch.object(supportinfo, "_current_user", return_value="root"), \
+         patch("subprocess.run", side_effect=_systemctl_side_effect(
+             units_stdout="", files_stdout="",
+             user_units_stdout="mpd.service loaded active running",
+             user_files_stdout="mpd.service enabled enabled",
+         )):
+        result = supportinfo.collect_services()
+    assert "(user scope: from /etc/hifiberry.user)" in result
+    assert "realname" not in result
+
+
+def test_collect_services_notes_the_linger_detection_source():
+    with patch.object(supportinfo, "_detect_player_user", return_value=("realname", "from linger (single account)")), \
+         patch.object(supportinfo, "_current_user", return_value="root"), \
+         patch("subprocess.run", side_effect=_systemctl_side_effect(
+             units_stdout="", files_stdout="",
+             user_units_stdout="mpd.service loaded active running",
+             user_files_stdout="mpd.service enabled enabled",
+         )):
+        result = supportinfo.collect_services()
+    assert "(user scope: from linger (single account))" in result
+    assert "realname" not in result
+
+
+def test_collect_services_notes_the_ambiguous_detection_failure():
+    with patch.object(
+        supportinfo, "_detect_player_user",
+        return_value=(None, "ambiguous player user: 2 lingering users found, none chosen"),
+    ), patch("subprocess.run", side_effect=_systemctl_side_effect(units_stdout="", files_stdout="")):
+        result = supportinfo.collect_services()
+    assert "(user services unavailable: ambiguous player user:" in result
+    assert "none chosen" in result
+
+
+def test_collect_services_notes_the_no_user_found_detection_failure():
+    with patch.object(
+        supportinfo, "_detect_player_user",
+        return_value=(None, "no player user found (/etc/hifiberry.user missing and no lingering user in /var/lib/systemd/linger/)"),
+    ), patch("subprocess.run", side_effect=_systemctl_side_effect(units_stdout="", files_stdout="")):
+        result = supportinfo.collect_services()
+    assert "(user services unavailable: no player user found" in result
+
+
+def test_collect_services_never_prints_the_player_username():
+    # The property the coordinator asked to depend on, exercised across a
+    # realistic run: the account is found (via the file), used to build a
+    # --machine target, and successfully queried -- the only place a real
+    # username could leak into the report.
+    with patch.object(supportinfo, "_detect_player_user", return_value=("mrsmith", "from /etc/hifiberry.user")), \
+         patch.object(supportinfo, "_current_user", return_value="root"), \
+         patch("subprocess.run", side_effect=_systemctl_side_effect(
+             units_stdout="config-server.service loaded active running",
+             files_stdout="config-server.service enabled enabled",
+             user_units_stdout="mpd.service loaded active running",
+             user_files_stdout="mpd.service enabled enabled",
+         )):
+        result = supportinfo.collect_services()
+    assert "mrsmith" not in result
+    assert "config-server.service" in result and "mpd.service" in result
+
+
+def test_collect_services_scrubs_the_username_from_a_machine_connection_failure():
+    # systemctl's own failure text for --machine=<user>@.host routinely
+    # echoes the machine spec back (e.g. "Failed to connect to machine
+    # mrsmith@.host: Host is down") -- that text flows straight into a
+    # "(command failed: ...)" note via _run(), which is not otherwise
+    # redacted (redact_secrets targets credentials, not usernames). The
+    # username must not survive into the rendered report through that path
+    # either.
+    with patch.object(supportinfo, "_detect_player_user", return_value=("mrsmith", "from /etc/hifiberry.user")), \
+         patch.object(supportinfo, "_current_user", return_value="root"), \
+         patch("subprocess.run", side_effect=_systemctl_side_effect(
+             units_stdout="config-server.service loaded active running",
+             files_stdout="config-server.service enabled enabled",
+             user_units_result=_failed("Failed to connect to machine mrsmith@.host: Host is down"),
+             user_files_result=_failed("Failed to connect to machine mrsmith@.host: Host is down"),
+         )):
+        result = supportinfo.collect_services()
+    assert "mrsmith" not in result
+    assert "Host is down" in result  # the rest of the failure reason survives
+    assert "user running state unavailable" in result


### PR DESCRIPTION
## Summary
Three rounds on top of #15 (2.15.4, merged):

**2.15.5 -- rendering fix.** Aligned the merged Services table (computed
column widths, glyph stripping, explicit placeholders) after real hardware
showed it wasn't scannable.

**2.15.6 -- the player-user gap.** On HiFiBerryOS the player daemons run as
systemd *user* services, not system services, so the Services section was
silent for exactly the reports that matter most. `collect_services()` now
also queries the player user's `systemctl --user` instance (user found via
`/etc/hifiberry.user`, falling back to the sole lingering user), using
`--user` directly or `--machine=<user>@.host` depending on who
config-supportinfo runs as. System and user scopes get a SCOPE column and
are never merged by unit name, since both define units of the same name.

**2.15.7 -- review fixes.**
1. The table never said *how* the player user was found, so a wrong guess
   was undetectable -- fixed by noting the detection *source*
   ("user scope: from /etc/hifiberry.user" / "... from linger (single
   account)"), never the username itself (a real person's login name,
   same reason the hostname is already omitted). A failure message that
   could otherwise echo the account back (a refused `--machine=`
   connection) is scrubbed too.
2. `_read_hifiberry_user_file()` returned a comment line verbatim as the
   username (e.g. `# the player user`) instead of falling through to
   linger. Now skips blank/`#`-comment lines and validates the rest
   against a conservative username pattern.
3. `_LEADING_GLYPH` wasn't anchored past leading whitespace -- one-char
   fix (`\s*`).

`/etc/hifiberry.user` wins over the linger fallback unconditionally when
it resolves to a valid name; linger is never consulted in that case.

Bumped to 2.15.7 with a matching changelog entry and man page version.

## Test plan
- [x] `python3 -m pytest` -- 307 passed, 1 skipped (pre-existing, unrelated)
- [x] Alignment-property tests (2.15.5), user-scope detection/collision/
      failure tests (2.15.6), plus (2.15.7): comment-only and
      invalid-username fallthrough, leading-whitespace glyph, the
      detection-source note for the file/linger/ambiguous/none cases, and
      a dedicated test that the username never appears anywhere in
      rendered output -- including through a scrubbed machine-connection
      failure message