### PR TITLE
supportinfo: move journal dedup count marker to line start, align columns

### DIFF
--- a/configurator/_version.py
+++ b/configurator/_version.py
@@ -4,7 +4,7 @@ Version information for HiFiBerry Configurator
 Single source of truth for version number
 """
 
-__version__ = "2.15.7"
+__version__ = "2.15.8"
 __version_info__ = tuple(map(int, __version__.split('.')))
 
 # For backward compatibility

--- a/configurator/supportinfo.py
+++ b/configurator/supportinfo.py
@@ -740,6 +740,19 @@ def _dedup_journal(text: str, keep: int) -> str:
     entries are kept: the most recently-first-seen ones, i.e. the last
     `keep` messages to appear for the first time in the input, still shown
     in that same chronological order.
+
+    The occurrence count is rendered as a "(xN)" marker at the *start* of
+    the line, not the end. redact_secrets()'s Authorization-header pattern
+    is deliberately greedy -- a credential can contain almost any character,
+    so it replaces everything from the auth scheme to end of line -- and a
+    trailing "(xN)" on a redacted line would fall inside that span and
+    vanish, silently turning "this failed 37 times" back into "this failed"
+    for exactly the lines where the repeat count matters most. A leading
+    marker sits before anything redaction ever touches, so it survives
+    structurally instead of needing redaction to special-case this format.
+    Markers are right-aligned to a common width and lines with no repeat
+    are left-padded by that same width, so every timestamp still starts in
+    the same column and the section stays scannable.
     """
     if not text:
         return text
@@ -762,12 +775,23 @@ def _dedup_journal(text: str, keep: int) -> str:
             order.append(message)
 
     kept = order[-keep:] if keep > 0 else []
+    markers = {
+        message: f"(x{entries[message]['count']})"
+        for message in kept
+        if entries[message]["count"] > 1
+    }
+    width = max((len(marker) for marker in markers.values()), default=0)
+
     rendered = []
     for message in kept:
         entry = entries[message]
-        prefix = f"{entry['timestamp']} " if entry["timestamp"] else ""
-        suffix = f" (x{entry['count']})" if entry["count"] > 1 else ""
-        rendered.append(f"{prefix}{message}{suffix}")
+        line = ""
+        if width:
+            line += markers.get(message, "").rjust(width) + " "
+        if entry["timestamp"]:
+            line += f"{entry['timestamp']} "
+        line += message
+        rendered.append(line)
     return "\n".join(rendered)
 
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,21 @@
+hifiberry-configurator (2.15.8) stable; urgency=medium
+
+  * config-supportinfo: move the "Recent errors" repeat-count marker
+    ("(xN)") from the end of a deduplicated journal line to the start.
+    This is a readability fix -- markers are right-aligned to a common
+    width and unrepeated lines are indented to match, so timestamps stay
+    in one column instead of going ragged -- but it also fixes a real
+    loss of information: redact_secrets()'s Authorization-header pattern
+    is deliberately greedy from the auth scheme to end of line (a
+    credential can contain almost any character), so a trailing count on
+    a redacted auth-failure line used to fall inside the redacted span
+    and disappear, silently turning "this failed 37 times" back into
+    "this failed" for exactly the lines where the repeat count matters
+    most. A leading marker sits ahead of anything redaction touches, so
+    it survives structurally.
+
+ -- HiFiBerry <support@hifiberry.com>  Fri, 07 Aug 2026 16:00:00 +0200
+
 hifiberry-configurator (2.15.7) stable; urgency=medium
 
   * config-supportinfo: review fixes for the player-user Services query

--- a/man/config-supportinfo.1
+++ b/man/config-supportinfo.1
@@ -1,4 +1,4 @@
-.TH CONFIG-SUPPORTINFO 1 "August 2026" "configurator 2.15.7" "HiFiBerry Configuration Tools"
+.TH CONFIG-SUPPORTINFO 1 "August 2026" "configurator 2.15.8" "HiFiBerry Configuration Tools"
 .SH NAME
 config-supportinfo \- collect a diagnostic report for bug reports
 .SH SYNOPSIS

--- a/tests/test_supportinfo_commands.py
+++ b/tests/test_supportinfo_commands.py
@@ -122,6 +122,74 @@ def test_collect_journal_keeps_a_rare_error_distinct_from_a_dominant_repeat():
     assert result.index("rare disk I/O error") < result.index("ble-provisioning")
 
 
+def test_dedup_journal_puts_the_count_marker_at_the_start_not_the_end():
+    repeated = "\n".join(
+        f"Aug 07 09:{50 + i:02d}:00 systemd[1]: Failed to start "
+        "ble-provisioning.service - HiFiBerry BLE WiFi Provisioning."
+        for i in range(5)
+    )
+    with patch("subprocess.run", return_value=_completed(repeated)):
+        result = supportinfo.collect_journal(lines=40)
+    line = result.splitlines()[0]
+    assert line.startswith("(x5)")
+    assert not line.rstrip().endswith("(x5)")
+
+
+def test_journal_dedup_count_survives_redaction_of_an_authorization_header_line():
+    # The actual bug: redact_secrets' Authorization-header pattern is
+    # deliberately greedy (a credential can contain almost any character),
+    # replacing everything from the auth scheme to end of line. A count
+    # marker appended at the end of the line used to fall inside that span
+    # and vanish. Asserted end-to-end, through redact_secrets, not just on
+    # the renderer's own output.
+    raw = "\n".join(
+        f"Aug 07 10:27:{i:02d} nginx[1]: auth rejected, "
+        "Authorization: Basic am9lOmh1bnRlcjI="
+        for i in range(37)
+    )
+    with patch("subprocess.run", return_value=_completed(raw)):
+        deduped = supportinfo.collect_journal(lines=40)
+    redacted = supportinfo.redact_secrets(deduped)
+    assert "(x37)" in redacted
+    assert "am9lOmh1bnRlcjI=" not in redacted
+    assert "***REDACTED***" in redacted
+
+
+_JOURNAL_TS_IN_OUTPUT = re.compile(r"Aug \d{2} \d{2}:\d{2}:\d{2}")
+
+
+def test_dedup_journal_aligns_counted_and_uncounted_lines():
+    raw = "\n".join(
+        ["Aug 07 09:00:00 kernel: rare disk I/O error on sda1"]
+        + [
+            f"Aug 07 09:{10 + i:02d}:00 systemd[1]: Failed to start "
+            "ble-provisioning.service - HiFiBerry BLE WiFi Provisioning."
+            for i in range(5)
+        ]
+    )
+    with patch("subprocess.run", return_value=_completed(raw)):
+        result = supportinfo.collect_journal(lines=40)
+    lines = result.splitlines()
+    assert len(lines) == 2
+    offsets = [_JOURNAL_TS_IN_OUTPUT.search(line).start() for line in lines]
+    assert offsets[0] == offsets[1]
+
+
+def test_dedup_journal_aligns_a_three_digit_count_with_a_single_digit_count():
+    raw = "\n".join(
+        ["Aug 07 09:00:00 systemd[1]: Failed to start ble-provisioning.service."] * 400
+        + ["Aug 07 09:00:01 nginx[1]: connection reset by peer"] * 2
+    )
+    with patch("subprocess.run", return_value=_completed(raw)):
+        result = supportinfo.collect_journal(lines=40)
+    lines = result.splitlines()
+    assert len(lines) == 2
+    assert "(x400)" in lines[0]
+    assert "(x2)" in lines[1]
+    offsets = [_JOURNAL_TS_IN_OUTPUT.search(line).start() for line in lines]
+    assert offsets[0] == offsets[1]
+
+
 def test_collect_packages_drops_entries_with_no_version():
     # dpkg knows the name (it's in a PACKAGE_PATTERNS entry) but nothing of
     # that name is installed, so dpkg-query prints the name with an empty


### PR DESCRIPTION
## Summary
- Moves the "Recent errors" dedup repeat-count marker (`(xN)`) from the end of a line to the start. `redact_secrets()`'s Authorization-header pattern is deliberately greedy from the auth scheme to end of line (a credential can contain almost any character), so a trailing count on a redacted auth-failure line fell inside the redacted span and disappeared — silently turning "this failed 37 times" back into "this failed" for exactly the lines where the count matters most. A leading marker sits ahead of anything redaction touches, so it survives structurally instead of teaching redaction about this format.
- Markers are right-aligned to a common width (based on the widest count in the section) and unrepeated lines are left-padded by that same width, so timestamps stay in one column instead of going ragged when a `(x2)` sits next to a `(x400)`.
- Nothing about what's collected, the fetch multiplier, or the dedup keying changed — only `_dedup_journal`'s final render step.
- Version bump to 2.15.8 with a changelog entry.

## Rendered sample (mixed counted/uncounted, includes an Authorization line)
```
       Aug 07 09:00:00 kernel: rare disk I/O error on sda1
 (x37) Aug 07 10:27:36 nginx[1]: auth rejected, Authorization: Basic ***REDACTED***
(x400) Aug 07 10:36:39 systemd[1]: Failed to start ble-provisioning.service - HiFiBerry BLE WiFi Provisioning.
```

## Test plan
- [x] `python3 -m pytest tests/test_supportinfo_commands.py -q` — 54 passed
- [x] `python3 -m pytest -q` (full suite) — 311 passed, 1 skipped
- [x] New tests: count marker appears at line start and not at line end; a line carrying an `Authorization` header keeps its count after `redact_secrets()` runs over it (asserted end-to-end); counted and uncounted lines align at the same timestamp column offset; a three-digit count (`x400`) next to a single-digit one (`x2`) still aligns.