### PR TITLE
Add an authenticated supportinfo endpoint

### DIFF
--- a/configurator/_version.py
+++ b/configurator/_version.py
@@ -4,7 +4,7 @@ Version information for HiFiBerry Configurator
 Single source of truth for version number
 """
 
-__version__ = "2.15.8"
+__version__ = "2.15.9"
 __version_info__ = tuple(map(int, __version__.split('.')))
 
 # For backward compatibility

--- a/configurator/server.py
+++ b/configurator/server.py
@@ -253,7 +253,29 @@ class ConfigAPIServer:
                     'message': 'Failed to retrieve system information',
                     'error': str(e)
                 }), 500
-        
+
+        # Support report endpoint (authenticated: not in the auth policy's "ok" list)
+        @self.app.route('/api/v1/supportinfo', methods=['GET'])
+        def get_support_info():
+            """Diagnostic report for bug reports, as redacted plain text.
+
+            Calls exactly the functions config-supportinfo uses, so the
+            redaction that guards the CLI guards this endpoint too. Do not
+            reimplement collection or redaction here.
+            """
+            from . import supportinfo
+            try:
+                text = supportinfo.render_text(supportinfo.build_report())
+            except Exception as e:
+                logger.error(f"Error generating support info: {e}")
+                return jsonify({
+                    'status': 'error',
+                    'message': 'Failed to generate support information',
+                }), 500
+            return make_response(
+                (text, 200, {'Content-Type': 'text/plain; charset=utf-8'})
+            )
+
         # Configuration endpoints using configdb handlers
         @self.app.route('/api/v1/keys', methods=['GET'])
         def get_config_keys():

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+hifiberry-configurator (2.15.9) stable; urgency=medium
+
+  * Add an authenticated /supportinfo endpoint that serves the same redacted
+    diagnostic report as config-supportinfo, for the WebUI download.
+
+ -- HiFiBerry <support@hifiberry.com>  Fri, 07 Aug 2026 15:18:19 +0200
+
 hifiberry-configurator (2.15.8) stable; urgency=medium
 
   * config-supportinfo: move the "Recent errors" repeat-count marker

--- a/man/config-supportinfo.1
+++ b/man/config-supportinfo.1
@@ -1,4 +1,4 @@
-.TH CONFIG-SUPPORTINFO 1 "August 2026" "configurator 2.15.8" "HiFiBerry Configuration Tools"
+.TH CONFIG-SUPPORTINFO 1 "August 2026" "configurator 2.15.9" "HiFiBerry Configuration Tools"
 .SH NAME
 config-supportinfo \- collect a diagnostic report for bug reports
 .SH SYNOPSIS

--- a/tests/test_auth_policy_supportinfo.py
+++ b/tests/test_auth_policy_supportinfo.py
@@ -1,16 +1,72 @@
 # tests/test_auth_policy_supportinfo.py
+import fnmatch
 import json
 import os
+
+import pytest
 
 POLICY = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
     "auth", "config.json",
 )
 
+# The endpoint under guard, in its two live representations:
+#  - SUPPORTINFO_REMAINDER: what an ok-rule "paths" pattern is actually
+#    matched against today, once this manifest's own match_prefix
+#    ("/api/config/v1") has been stripped from the request URI by
+#    hifiberry_auth.manifests.TierMap._manifest_for.
+#  - SUPPORTINFO_ROUTE: the raw Flask route registered in
+#    configurator/server.py (`/api/v1/supportinfo`). A pattern equal to
+#    this string is inert under today's match_prefix, but it unambiguously
+#    names the intent "let this endpoint through", and would go live the
+#    moment match_prefix or the service topology changes. Checked too, so
+#    that class of mistake doesn't sit dormant in the policy waiting for a
+#    future refactor to activate it.
+SUPPORTINFO_REMAINDER = "/supportinfo"
+SUPPORTINFO_ROUTE = "/api/v1/supportinfo"
+
 
 def _policy():
     with open(POLICY) as f:
         return json.load(f)
+
+
+# Mirrors hifiberry_auth.manifests._path_matches
+# (packages/hifiberry-auth/hifiberry-auth/src/hifiberry_auth/manifests.py)
+# exactly: split pattern and path on "/", compare segment by segment with
+# fnmatch.fnmatchcase, and treat a "**" segment as "matches the rest,
+# including nothing" (manifests.py requires it be last; this mirror does
+# too, since it returns as soon as it sees one). configurator cannot import
+# hifiberry-auth -- different package, not a dependency, and adding one is
+# out of scope -- so this is a small, explicit reimplementation rather than
+# an approximation. A prefix/substring check (what this file used to do)
+# is *not* equivalent: it misses globs like "/support*" or "/**" that the
+# real matcher would honor, which is how this gap got past review once
+# already. If manifests.py's matching semantics change, this comment is the
+# pointer to come re-check them.
+def _segments(path):
+    path = path.split("?", 1)[0].split("#", 1)[0]
+    return [s for s in path.strip("/").split("/") if s != ""]
+
+
+def _path_matches(pattern, path):
+    pat = _segments(pattern)
+    seg = _segments(path)
+    for i, p in enumerate(pat):
+        if p == "**":          # matches the rest, including nothing (must be last)
+            return True
+        if i >= len(seg) or not fnmatch.fnmatchcase(seg[i], p):
+            return False
+    return len(pat) == len(seg)
+
+
+def _ok_paths():
+    return [
+        path
+        for rule in _policy()["rules"]
+        if rule.get("tier") == "ok"
+        for path in rule.get("paths", [])
+    ]
 
 
 def test_default_tier_is_risky():
@@ -20,18 +76,39 @@ def test_default_tier_is_risky():
 def test_supportinfo_is_not_in_any_ok_rule():
     """The support report exposes journal errors, mount paths and the full
     package inventory — far more than /systeminfo, which is deliberately ok.
-    Adding /supportinfo to an ok rule would publish all of that to anyone on
-    the network. If this test fails, that is what has happened.
+    An ok-rule pattern that the gateway's matcher would actually match
+    against /supportinfo -- whether written as a literal path, a glob like
+    /support* or /**, or the raw internal route -- would publish all of
+    that to anyone on the network. If this test fails, that is what has
+    happened.
     """
-    for rule in _policy()["rules"]:
-        if rule.get("tier") != "ok":
-            continue
-        for path in rule.get("paths", []):
-            assert not path.startswith("/supportinfo"), (
-                f"/supportinfo must stay authenticated, found in ok rule: {path}"
+    for pattern in _ok_paths():
+        for candidate in (SUPPORTINFO_REMAINDER, SUPPORTINFO_ROUTE):
+            assert not _path_matches(pattern, candidate), (
+                f"/supportinfo must stay authenticated, but ok pattern "
+                f"{pattern!r} matches {candidate!r}"
             )
 
 
 def test_systeminfo_is_still_ok_so_the_test_above_is_meaningful():
-    ok_paths = [p for r in _policy()["rules"] if r.get("tier") == "ok" for p in r.get("paths", [])]
-    assert "/systeminfo" in ok_paths
+    assert "/systeminfo" in _ok_paths()
+
+
+# --- Guard the matcher itself: prove it recognizes the shapes that slipped
+# past the old prefix-only check, and that it doesn't fire on unrelated
+# entries (so it can't rot into "always fails"). These exercise
+# _path_matches() directly rather than mutating the real policy file, which
+# stays untouched by this test suite; the equivalent mutation was also run
+# by hand against the live auth/config.json (see task-12-report.md) to
+# confirm the guard above genuinely fails when one of these patterns is
+# actually added.
+@pytest.mark.parametrize("pattern", ["/support*", "/**", "/api/v1/supportinfo", "/supportinfo"])
+def test_matcher_recognizes_patterns_that_would_expose_supportinfo(pattern):
+    assert _path_matches(pattern, SUPPORTINFO_REMAINDER) or _path_matches(pattern, SUPPORTINFO_ROUTE), (
+        f"expected {pattern!r} to match one of the live supportinfo paths"
+    )
+
+
+def test_matcher_does_not_fire_on_an_unrelated_ok_pattern():
+    assert not _path_matches("/systeminfo", SUPPORTINFO_REMAINDER)
+    assert not _path_matches("/systeminfo", SUPPORTINFO_ROUTE)

--- a/tests/test_auth_policy_supportinfo.py
+++ b/tests/test_auth_policy_supportinfo.py
@@ -1,0 +1,37 @@
+# tests/test_auth_policy_supportinfo.py
+import json
+import os
+
+POLICY = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "auth", "config.json",
+)
+
+
+def _policy():
+    with open(POLICY) as f:
+        return json.load(f)
+
+
+def test_default_tier_is_risky():
+    assert _policy()["default_tier"] == "risky"
+
+
+def test_supportinfo_is_not_in_any_ok_rule():
+    """The support report exposes journal errors, mount paths and the full
+    package inventory — far more than /systeminfo, which is deliberately ok.
+    Adding /supportinfo to an ok rule would publish all of that to anyone on
+    the network. If this test fails, that is what has happened.
+    """
+    for rule in _policy()["rules"]:
+        if rule.get("tier") != "ok":
+            continue
+        for path in rule.get("paths", []):
+            assert not path.startswith("/supportinfo"), (
+                f"/supportinfo must stay authenticated, found in ok rule: {path}"
+            )
+
+
+def test_systeminfo_is_still_ok_so_the_test_above_is_meaningful():
+    ok_paths = [p for r in _policy()["rules"] if r.get("tier") == "ok" for p in r.get("paths", [])]
+    assert "/systeminfo" in ok_paths

--- a/tests/test_server_supportinfo.py
+++ b/tests/test_server_supportinfo.py
@@ -1,0 +1,41 @@
+# tests/test_server_supportinfo.py
+from unittest.mock import patch
+
+import pytest
+
+from configurator.server import ConfigAPIServer
+
+
+@pytest.fixture
+def client():
+    server = ConfigAPIServer()
+    server.app.config["TESTING"] = True
+    with server.app.test_client() as c:
+        yield c
+
+
+def test_supportinfo_returns_plain_text(client):
+    with patch("configurator.supportinfo.build_report", return_value={"System": {"Pi Model": "Pi 5"}}), \
+         patch("configurator.supportinfo.render_text", return_value="## System\nPi Model: Pi 5\n"):
+        response = client.get("/api/v1/supportinfo")
+    assert response.status_code == 200
+    assert response.mimetype == "text/plain"
+    assert "Pi Model: Pi 5" in response.get_data(as_text=True)
+
+
+def test_supportinfo_uses_the_shared_cli_code_path(client):
+    with patch("configurator.supportinfo.build_report", return_value={}) as build, \
+         patch("configurator.supportinfo.render_text", return_value="") as render:
+        client.get("/api/v1/supportinfo")
+    build.assert_called_once()
+    render.assert_called_once()
+
+
+def test_supportinfo_failure_returns_500_without_leaking_details(client):
+    boom = RuntimeError("/home/someuser/secret-path exploded")
+    with patch("configurator.supportinfo.build_report", side_effect=boom):
+        response = client.get("/api/v1/supportinfo")
+    assert response.status_code == 500
+    body = response.get_data(as_text=True)
+    assert "someuser" not in body
+    assert "secret-path" not in body


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/supportinfo` (external `/api/config/v1/supportinfo`), which serves the same redacted diagnostic report as `config-supportinfo` over HTTP, so the web interface can offer a download without a terminal. The handler calls only `supportinfo.build_report()` and `supportinfo.render_text()` — the same functions the CLI uses — so it carries no separate collection or redaction logic and inherits any future improvement to that shared code automatically.
- The endpoint stays on the risky auth tier by inheriting the policy default (`auth/config.json` is unchanged); it is deliberately not added to the unauthenticated `ok` allowlist that `/systeminfo` uses, since the report contains journal errors, mount paths and the full package inventory.
- A guard test (`tests/test_auth_policy_supportinfo.py`) keeps it that way. It mirrors the auth gateway's own glob matcher (`hifiberry_auth.manifests._path_matches`: segment split + `fnmatch.fnmatchcase` per segment, with `**` short-circuit) rather than a naive string-prefix check, so it catches not just a literal `/supportinfo` entry but glob-based accidental exposure too (e.g. `/support*`, `/**`), plus a defensive check against the raw internal route string.
- Version bumped to 2.15.9 (`configurator/_version.py`, `debian/changelog`, `man/config-supportinfo.1` moved together).

## Test plan

- [x] `tests/test_server_supportinfo.py` (3 tests) — endpoint returns redacted plain text, calls the shared build_report/render_text path exactly once each, and returns 500 without leaking exception details.
- [x] `tests/test_auth_policy_supportinfo.py` (8 tests) — default tier is risky, `/supportinfo` isn't matched by any `ok` rule (via the real gateway matcher semantics), `/systeminfo` is still ok, and the matcher itself is proven to recognize `/support*`, `/**`, `/api/v1/supportinfo` and `/supportinfo` as matches while not firing on `/systeminfo`.
- [x] Full suite via `.venv-test/bin/python -m pytest -q`: 351 passed.