### PR TITLE
Fix supportinfo test collection, access-path visibility, and endpoint logging

### DIFF
--- a/configurator/_version.py
+++ b/configurator/_version.py
@@ -4,7 +4,7 @@ Version information for HiFiBerry Configurator
 Single source of truth for version number
 """
 
-__version__ = "2.15.9"
+__version__ = "2.15.10"
 __version_info__ = tuple(map(int, __version__.split('.')))
 
 # For backward compatibility

--- a/configurator/_version.py
+++ b/configurator/_version.py
@@ -4,7 +4,7 @@ Version information for HiFiBerry Configurator
 Single source of truth for version number
 """
 
-__version__ = "2.15.10"
+__version__ = "2.15.11"
 __version_info__ = tuple(map(int, __version__.split('.')))
 
 # For backward compatibility

--- a/configurator/server.py
+++ b/configurator/server.py
@@ -275,8 +275,8 @@ class ConfigAPIServer:
             try:
                 # The CLI silences the collectors' own WARNING/ERROR logging
                 # via setup_logging(); this route needs the same quiet, but
-                # scoped to this one request instead of config-server's whole
-                # process -- see quiet_collectors().
+                # scoped to this one request's thread instead of
+                # config-server's whole process -- see quiet_collectors().
                 with supportinfo.quiet_collectors():
                     text = supportinfo.render_text(supportinfo.build_report())
             except Exception as e:

--- a/configurator/server.py
+++ b/configurator/server.py
@@ -262,10 +262,23 @@ class ConfigAPIServer:
             Calls exactly the functions config-supportinfo uses, so the
             redaction that guards the CLI guards this endpoint too. Do not
             reimplement collection or redaction here.
+
+            config-server always runs as root, never as the player user, so
+            the user-services collector's own-session-bus branch never
+            applies here -- this route always takes the `--machine=<user>@.host`
+            path (see _collect_user_service_rows), which needs machined and a
+            reachable linger session and can fail where a same-user CLI
+            invocation would not. The Services section records which path
+            was used for exactly this reason.
             """
             from . import supportinfo
             try:
-                text = supportinfo.render_text(supportinfo.build_report())
+                # The CLI silences the collectors' own WARNING/ERROR logging
+                # via setup_logging(); this route needs the same quiet, but
+                # scoped to this one request instead of config-server's whole
+                # process -- see quiet_collectors().
+                with supportinfo.quiet_collectors():
+                    text = supportinfo.render_text(supportinfo.build_report())
             except Exception as e:
                 logger.error(f"Error generating support info: {e}")
                 return jsonify({

--- a/configurator/supportinfo.py
+++ b/configurator/supportinfo.py
@@ -15,6 +15,7 @@ import platform
 import re
 import subprocess
 import sys
+import threading
 
 REDACTED = "***REDACTED***"
 
@@ -913,28 +914,82 @@ def setup_logging(verbose=False):
     root_logger.addHandler(console_handler)
 
 
+# quiet_collectors() started out as a save/restore of the root logger's
+# *level*, mirroring setup_logging() below. That is wrong for a
+# multi-threaded, long-lived process: the level is one piece of state
+# shared by every thread, so two overlapping calls -- config-server runs
+# under waitress with several worker threads, and collection shells out to
+# journalctl/dpkg-query for seconds, so two /supportinfo requests (or one
+# of those overlapping any other route) is not a corner case -- race on
+# who's "previous" level was actually the original. If the thread that
+# entered first also exits first, the second thread's exit restores the
+# *already-raised* level it saved on entry, re-silencing the process with
+# nothing left to ever lower it again. The same design also silences every
+# other thread's logging -- other routes, waitress itself -- for the
+# whole multi-second collection, not just the collectors, since the level
+# is process-wide, not per-caller.
+#
+# A logging.Filter keyed on a threading.local() flag has neither problem.
+# Filter.filter() always runs synchronously on the thread that made the
+# logging call (Python's logging is not queued unless a QueueHandler sits
+# in the chain, which config-server's does not), so each thread reads and
+# writes only its own flag -- no lock, no shared counter, no state for a
+# second thread to race. And a thread that never entered quiet_collectors()
+# is never affected by one that did, which fixes the milder problem too.
+#
+# The filter has to be attached to *handlers*, not to the root logger's
+# own .filters: a Logger's .filters are only consulted for records that
+# logger originates itself (Logger.handle() calls self.filter() once, at
+# the point of origin); a record merely propagating up from a child logger
+# (e.g. "configurator.systeminfo") never re-runs an ancestor's .filters,
+# only its .filters on each *handler* it reaches via callHandlers(). The
+# filter is attached once per handler and never removed -- Handler.addFilter
+# already no-ops for an instance that's already attached, so re-attaching
+# on every call is harmless, and never removing it means there is no
+# teardown step left to race between overlapping calls; an attached filter
+# is a no-op for any thread whose flag is not set.
+_quiet_thread_state = threading.local()
+
+
+class _CollectorQuietFilter(logging.Filter):
+    """Drops a record iff the thread that emitted it is inside quiet_collectors()."""
+
+    def filter(self, record):
+        return not getattr(_quiet_thread_state, "active", False)
+
+
+_QUIET_FILTER = _CollectorQuietFilter()
+
+
+def _install_quiet_filter(root_logger):
+    for handler in root_logger.handlers:
+        handler.addFilter(_QUIET_FILTER)
+
+
 @contextlib.contextmanager
 def quiet_collectors():
     """Silence the collectors' WARNING/ERROR logging for the duration of a call.
 
     setup_logging() is the CLI's answer to the same noise (see its
-    docstring), but it is not safe for a long-lived process to call: it
-    tears down and replaces every handler on the root logger, which for
-    config-supportinfo's one-shot process is fine and for config-server --
-    whose other routes must keep logging exactly as they already do --
-    would be a permanent, global side effect of one route. This only raises
-    the root logger's *level* for the lifetime of the with-block and always
-    restores the previous level on the way out, success or exception, so it
-    can wrap a single request's collection without touching config-server's
-    own handlers or leaking the change into the requests that follow.
+    docstring), but it is not safe for a long-lived, multi-threaded process
+    to call: it tears down and replaces every handler on the root logger,
+    which for config-supportinfo's one-shot process is fine and for
+    config-server -- whose other routes must keep logging exactly as they
+    already do, even while a collection is running on another thread --
+    would be a permanent, global side effect of one route. This attaches a
+    thread-scoped logging.Filter (see above) rather than touching the root
+    logger's level or handlers at all, so it can wrap a single request's
+    collection without affecting any other thread, whether that thread is
+    running a concurrent /supportinfo request, a different route, or
+    waitress itself.
     """
     root_logger = logging.getLogger()
-    previous_level = root_logger.level
-    root_logger.setLevel(logging.CRITICAL)
+    _install_quiet_filter(root_logger)
+    _quiet_thread_state.active = True
     try:
         yield
     finally:
-        root_logger.setLevel(previous_level)
+        _quiet_thread_state.active = False
 
 
 def main(argv=None) -> int:

--- a/configurator/supportinfo.py
+++ b/configurator/supportinfo.py
@@ -6,6 +6,7 @@ everything it prints passes through redact_secrets() first.
 """
 
 import argparse
+import contextlib
 import getpass
 import json
 import logging
@@ -648,18 +649,27 @@ def _collect_user_service_rows() -> tuple:
     (_detect_player_user's source string) rather than the username itself
     -- so a maintainer can tell a file-based detection from a linger guess
     and spot a wrong one, without the report ever containing what is, on
-    every device seen so far, a person's real login name.
+    every device seen so far, a person's real login name. The same note
+    also records *which* of the two access paths above was taken (direct
+    session bus vs. --machine): the collection functions are shared between
+    the CLI and the config-server endpoint, but which path runs is decided
+    by the calling process's own identity, which is not shared -- the CLI
+    usually runs as the player user itself, config-server always runs as
+    root. The two paths can behave differently (--machine depends on
+    machined and a reachable linger session), so a reader comparing a bug
+    report against what the CLI shows locally needs to know which path
+    produced the rows in front of them.
     """
     player_user, source = _detect_player_user()
     if player_user is None:
         return [], [f"(user services unavailable: {source})"]
 
-    notes = [f"(user scope: {source})"]
-
     machine = (
         [] if _current_user() == player_user
         else [f"--machine={player_user}@.host"]
     )
+    access = "direct session bus" if not machine else "via --machine"
+    notes = [f"(user scope: {source}; access: {access})"]
 
     units_raw = _scrub_username(
         _run(
@@ -901,6 +911,30 @@ def setup_logging(verbose=False):
     console_handler.setFormatter(formatter)
 
     root_logger.addHandler(console_handler)
+
+
+@contextlib.contextmanager
+def quiet_collectors():
+    """Silence the collectors' WARNING/ERROR logging for the duration of a call.
+
+    setup_logging() is the CLI's answer to the same noise (see its
+    docstring), but it is not safe for a long-lived process to call: it
+    tears down and replaces every handler on the root logger, which for
+    config-supportinfo's one-shot process is fine and for config-server --
+    whose other routes must keep logging exactly as they already do --
+    would be a permanent, global side effect of one route. This only raises
+    the root logger's *level* for the lifetime of the with-block and always
+    restores the previous level on the way out, success or exception, so it
+    can wrap a single request's collection without touching config-server's
+    own handlers or leaking the change into the requests that follow.
+    """
+    root_logger = logging.getLogger()
+    previous_level = root_logger.level
+    root_logger.setLevel(logging.CRITICAL)
+    try:
+        yield
+    finally:
+        root_logger.setLevel(previous_level)
 
 
 def main(argv=None) -> int:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,21 @@
+hifiberry-configurator (2.15.10) stable; urgency=medium
+
+  * tests: guard test_server_supportinfo.py's flask import with
+    pytest.importorskip, so a checkout without flask installed no longer
+    aborts collection for the whole suite (every other test was being
+    silently skipped along with it).
+  * config-supportinfo: the Services section now also records which access
+    path (direct session bus vs. --machine) was used to reach the player
+    user's systemd --user instance, since config-server (always root) and
+    the CLI (usually the player user) can take different paths and only
+    one of them is exercised on a given device.
+  * server: scope-silence the supportinfo collectors' own WARNING/ERROR
+    logging to the /supportinfo request instead of leaving it unconfigured,
+    so repeated UI requests no longer spam config-server's journal; other
+    routes' logging is unaffected once the request completes.
+
+ -- HiFiBerry <support@hifiberry.com>  Fri, 07 Aug 2026 17:05:00 +0200
+
 hifiberry-configurator (2.15.9) stable; urgency=medium
 
   * Add an authenticated /supportinfo endpoint that serves the same redacted

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,23 @@
+hifiberry-configurator (2.15.11) stable; urgency=medium
+
+  * server: fix a critical regression in the previous release's
+    quiet_collectors(): it saved/restored the root logger's *level*, which
+    is shared, mutable, process-wide state. Two overlapping calls -- easy
+    to trigger, since config-server runs under waitress with several
+    worker threads and collection shells out to journalctl/dpkg-query for
+    seconds -- could race such that the second call's exit re-raised the
+    level right after the first call's exit had correctly lowered it, with
+    nothing left to ever lower it again: config-server's logging would
+    stop permanently, silently. The same design also silenced every other
+    thread's logging (other routes, waitress itself) for the whole
+    collection, not just the collectors'. Replaced with a thread-scoped
+    logging.Filter, keyed off a threading.local() flag rather than any
+    shared state, attached to root's handlers and left permanently
+    installed (a no-op for any thread not currently inside
+    quiet_collectors()) instead of being added and removed per call.
+
+ -- HiFiBerry <support@hifiberry.com>  Fri, 07 Aug 2026 18:20:00 +0200
+
 hifiberry-configurator (2.15.10) stable; urgency=medium
 
   * tests: guard test_server_supportinfo.py's flask import with

--- a/man/config-supportinfo.1
+++ b/man/config-supportinfo.1
@@ -1,4 +1,4 @@
-.TH CONFIG-SUPPORTINFO 1 "August 2026" "configurator 2.15.10" "HiFiBerry Configuration Tools"
+.TH CONFIG-SUPPORTINFO 1 "August 2026" "configurator 2.15.11" "HiFiBerry Configuration Tools"
 .SH NAME
 config-supportinfo \- collect a diagnostic report for bug reports
 .SH SYNOPSIS

--- a/man/config-supportinfo.1
+++ b/man/config-supportinfo.1
@@ -1,4 +1,4 @@
-.TH CONFIG-SUPPORTINFO 1 "August 2026" "configurator 2.15.9" "HiFiBerry Configuration Tools"
+.TH CONFIG-SUPPORTINFO 1 "August 2026" "configurator 2.15.10" "HiFiBerry Configuration Tools"
 .SH NAME
 config-supportinfo \- collect a diagnostic report for bug reports
 .SH SYNOPSIS

--- a/tests/test_pytest_collection_resilience.py
+++ b/tests/test_pytest_collection_resilience.py
@@ -1,0 +1,102 @@
+# tests/test_pytest_collection_resilience.py
+"""Guards against a specific regression: tests/test_server_supportinfo.py
+imports flask, a declared-but-not-guaranteed-installed dependency, and a
+bare `import flask` failure during collection does not just skip that one
+file -- pytest aborts collection entirely ("Interrupted: N errors during
+collection"), which silently skips every other test in the suite too.
+There is no CI to catch that, so the normal `python3 -m pytest tests/`
+command must keep working whether or not flask happens to be installed.
+
+Each test here runs pytest in a *subprocess* with flask hidden from
+sys.modules (rather than uninstalling it, which would affect the rest of
+this run) -- see _run_with_flask_hidden -- so the parent test run's own
+already-imported flask (if any) is unaffected.
+"""
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Runs pytest.main() in a fresh interpreter with sys.modules['flask'] set to
+# None first. That makes any subsequent `import flask` raise ImportError --
+# the same failure mode as flask simply not being installed -- without
+# actually uninstalling anything from the environment this test itself runs
+# in.
+_HIDE_FLASK_AND_RUN_PYTEST = (
+    "import sys; sys.modules['flask'] = None; "
+    "import pytest; sys.exit(pytest.main(sys.argv[1:]))"
+)
+
+
+def _run_with_flask_hidden(*pytest_args):
+    return subprocess.run(
+        [sys.executable, "-c", _HIDE_FLASK_AND_RUN_PYTEST, *pytest_args],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+def test_flask_dependent_file_is_skipped_not_a_collection_error():
+    """With flask hidden, the flask-dependent test module is skipped
+    (pytest.importorskip), not a collection error -- that is what keeps a
+    missing flask from taking the rest of the suite down with it."""
+    result = _run_with_flask_hidden("tests/test_server_supportinfo.py", "-q")
+    output = result.stdout + result.stderr
+    assert "Interrupted" not in output
+    assert "error" not in output.lower()
+    assert "1 skipped" in output
+    # Exit code 5 ("no tests ran") is expected here, not a failure: the
+    # module's only outcome is the import-time skip, so pytest collected
+    # zero runnable items from it. What this test guards against is exit
+    # code 2 (Interrupted) or a nonzero-because-of-an-error outcome from
+    # collection blowing up instead of degrading to a clean skip.
+    assert result.returncode in (0, 5)
+
+
+def test_full_suite_still_runs_and_reports_its_real_count_without_flask():
+    """The regression this guards against: `python3 -m pytest tests/`
+    aborting collection entirely and reporting nothing wrong. With flask
+    hidden, the rest of the suite (everything except the flask-dependent
+    modules) must still collect and run, and pytest's own exit code must
+    reflect that (0 -- skips are not failures).
+
+    Excludes this file itself: it spawns pytest subprocesses, so including
+    it in a subprocess's own "tests/" target would recursively spawn more
+    subprocesses doing the same thing.
+    """
+    result = _run_with_flask_hidden(
+        "tests/", "-q", "--ignore=tests/test_pytest_collection_resilience.py"
+    )
+    output = result.stdout + result.stderr
+    assert "Interrupted" not in output
+    assert "during collection" not in output
+    assert result.returncode == 0
+    # Comfortably more than the handful of files that could plausibly
+    # depend on flask -- proves the bulk of the suite actually ran rather
+    # than being silently swallowed by the collection abort this guards
+    # against.
+    assert " passed" in output
+    passed = int(output.split(" passed")[0].strip().split()[-1])
+    assert passed > 300
+
+
+def test_server_supportinfo_tests_execute_when_flask_is_present():
+    """The other direction: when flask *is* importable, the server tests
+    must not be silently skipped -- they need to actually run and pass."""
+    pytest.importorskip("flask", reason="only meaningful when flask is installed")
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", "tests/test_server_supportinfo.py", "-q"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    output = result.stdout + result.stderr
+    assert "skipped" not in output
+    assert "passed" in output
+    assert result.returncode == 0

--- a/tests/test_server_supportinfo.py
+++ b/tests/test_server_supportinfo.py
@@ -48,19 +48,22 @@ def test_supportinfo_failure_returns_500_without_leaking_details(client):
     assert "secret-path" not in body
 
 
-def test_supportinfo_endpoint_silences_collector_logging_during_collection(client):
+def test_supportinfo_endpoint_silences_collector_logging_during_collection(client, caplog):
     """setup_logging() is what keeps the CLI quiet; the endpoint does not
     call it (it must not permanently touch config-server's own logging --
     see the next test), so it needs its own, scoped way to silence the
     collectors' WARNING/ERROR noise for just this request. Simulates a
-    collector emitting a WARNING mid-collection and asserts the root
-    logger's effective level was raised enough to suppress it at the point
-    of the call.
+    collector emitting a WARNING mid-collection and asserts it never
+    reaches a handler at all.
+
+    quiet_collectors() is thread-scoped (see
+    tests/test_supportinfo_quiet_collectors_concurrency.py for the
+    dedicated concurrency coverage); this test just confirms the endpoint
+    actually invokes it around collection.
     """
-    seen_level = {}
+    caplog.set_level(logging.WARNING)
 
     def fake_build_report(*_a, **_kw):
-        seen_level["effective"] = logging.getLogger().getEffectiveLevel()
         logging.getLogger("configurator.systeminfo").warning(
             "collector noise that must not reach config-server's journal"
         )
@@ -71,7 +74,7 @@ def test_supportinfo_endpoint_silences_collector_logging_during_collection(clien
         response = client.get("/api/v1/supportinfo")
 
     assert response.status_code == 200
-    assert seen_level["effective"] >= logging.CRITICAL
+    assert "collector noise that must not reach config-server's journal" not in caplog.text
 
 
 def test_supportinfo_request_does_not_permanently_silence_other_routes(server, client, caplog):
@@ -80,7 +83,8 @@ def test_supportinfo_request_does_not_permanently_silence_other_routes(server, c
     every route that runs after it. Exercises supportinfo once (with a
     collector that logs, same as above), then hits a neighbouring route
     (systeminfo) that fails and logs its own error, and asserts that error
-    is still captured -- proving the root logger's level was restored.
+    is still captured -- proving the suppression did not outlive the
+    request that triggered it.
     """
     def fake_build_report(*_a, **_kw):
         logging.getLogger("configurator.systeminfo").warning("noise during supportinfo")

--- a/tests/test_server_supportinfo.py
+++ b/tests/test_server_supportinfo.py
@@ -1,15 +1,22 @@
 # tests/test_server_supportinfo.py
+import logging
 from unittest.mock import patch
 
 import pytest
+flask = pytest.importorskip("flask", reason="Flask is absent in the build chroot")
 
 from configurator.server import ConfigAPIServer
 
 
 @pytest.fixture
-def client():
-    server = ConfigAPIServer()
-    server.app.config["TESTING"] = True
+def server():
+    srv = ConfigAPIServer()
+    srv.app.config["TESTING"] = True
+    return srv
+
+
+@pytest.fixture
+def client(server):
     with server.app.test_client() as c:
         yield c
 
@@ -39,3 +46,58 @@ def test_supportinfo_failure_returns_500_without_leaking_details(client):
     body = response.get_data(as_text=True)
     assert "someuser" not in body
     assert "secret-path" not in body
+
+
+def test_supportinfo_endpoint_silences_collector_logging_during_collection(client):
+    """setup_logging() is what keeps the CLI quiet; the endpoint does not
+    call it (it must not permanently touch config-server's own logging --
+    see the next test), so it needs its own, scoped way to silence the
+    collectors' WARNING/ERROR noise for just this request. Simulates a
+    collector emitting a WARNING mid-collection and asserts the root
+    logger's effective level was raised enough to suppress it at the point
+    of the call.
+    """
+    seen_level = {}
+
+    def fake_build_report(*_a, **_kw):
+        seen_level["effective"] = logging.getLogger().getEffectiveLevel()
+        logging.getLogger("configurator.systeminfo").warning(
+            "collector noise that must not reach config-server's journal"
+        )
+        return {}
+
+    with patch("configurator.supportinfo.build_report", side_effect=fake_build_report), \
+         patch("configurator.supportinfo.render_text", return_value=""):
+        response = client.get("/api/v1/supportinfo")
+
+    assert response.status_code == 200
+    assert seen_level["effective"] >= logging.CRITICAL
+
+
+def test_supportinfo_request_does_not_permanently_silence_other_routes(server, client, caplog):
+    """The suppression above must be scoped to the one request -- a
+    supportinfo call must not leave config-server's own logging quiet for
+    every route that runs after it. Exercises supportinfo once (with a
+    collector that logs, same as above), then hits a neighbouring route
+    (systeminfo) that fails and logs its own error, and asserts that error
+    is still captured -- proving the root logger's level was restored.
+    """
+    def fake_build_report(*_a, **_kw):
+        logging.getLogger("configurator.systeminfo").warning("noise during supportinfo")
+        return {}
+
+    with patch("configurator.supportinfo.build_report", side_effect=fake_build_report), \
+         patch("configurator.supportinfo.render_text", return_value=""):
+        first = client.get("/api/v1/supportinfo")
+    assert first.status_code == 200
+
+    caplog.set_level(logging.ERROR, logger="configurator.server")
+    boom = RuntimeError("systeminfo exploded")
+    with patch.object(server.systeminfo, "get_system_info_dict", side_effect=boom):
+        second = client.get("/api/v1/systeminfo")
+
+    assert second.status_code == 500
+    assert any(
+        "Error getting system info" in record.message
+        for record in caplog.records
+    ), "neighbouring route's own error logging must survive a prior supportinfo request"

--- a/tests/test_supportinfo_commands.py
+++ b/tests/test_supportinfo_commands.py
@@ -690,7 +690,7 @@ def test_collect_user_services_uses_plain_user_flag_when_already_that_user():
              user_units_stdout="mpd.service loaded active running",
              user_files_stdout="mpd.service enabled enabled",
          )) as run:
-        supportinfo._collect_user_service_rows()
+        _, notes = supportinfo._collect_user_service_rows()
 
     commands = [call.args[0] for call in run.call_args_list]
     assert len(commands) == 2
@@ -698,6 +698,9 @@ def test_collect_user_services_uses_plain_user_flag_when_already_that_user():
         assert cmd[0] == "systemctl"
         assert "--user" in cmd
         assert not any(arg.startswith("--machine=") for arg in cmd)
+    # The report records which of the two access paths was actually taken,
+    # so a reader can tell a same-user collection from a --machine one.
+    assert "access: direct session bus" in notes[0]
 
 
 def test_collect_user_services_uses_machine_flag_when_a_different_user():
@@ -707,7 +710,7 @@ def test_collect_user_services_uses_machine_flag_when_a_different_user():
              user_units_stdout="mpd.service loaded active running",
              user_files_stdout="mpd.service enabled enabled",
          )) as run:
-        supportinfo._collect_user_service_rows()
+        _, notes = supportinfo._collect_user_service_rows()
 
     commands = [call.args[0] for call in run.call_args_list]
     assert len(commands) == 2
@@ -715,6 +718,10 @@ def test_collect_user_services_uses_machine_flag_when_a_different_user():
         assert cmd[0] == "systemctl"
         assert "--user" in cmd
         assert "--machine=matuschd@.host" in cmd
+    # Same note, but naming the other access path -- this is the case that
+    # matters most, since it is what config-server (always running as
+    # root) always takes.
+    assert "access: via --machine" in notes[0]
 
 
 def test_collect_services_distinguishes_same_named_units_by_scope():
@@ -837,8 +844,8 @@ def test_collect_services_alignment_holds_across_mixed_scope_rows():
     scopes = {_columns(r)[0] for r in rows}
     assert scopes == {"system", "user"}
     # And the note above the table names the detection source, not the
-    # account itself.
-    assert "(user scope: from /etc/hifiberry.user)" in result
+    # account itself, plus which access path was used to reach it.
+    assert "(user scope: from /etc/hifiberry.user; access: via --machine)" in result
     assert "matuschd" not in result
 
 
@@ -861,7 +868,7 @@ def test_collect_services_notes_the_file_detection_source():
              user_files_stdout="mpd.service enabled enabled",
          )):
         result = supportinfo.collect_services()
-    assert "(user scope: from /etc/hifiberry.user)" in result
+    assert "(user scope: from /etc/hifiberry.user; access: via --machine)" in result
     assert "realname" not in result
 
 
@@ -874,7 +881,7 @@ def test_collect_services_notes_the_linger_detection_source():
              user_files_stdout="mpd.service enabled enabled",
          )):
         result = supportinfo.collect_services()
-    assert "(user scope: from linger (single account))" in result
+    assert "(user scope: from linger (single account); access: via --machine)" in result
     assert "realname" not in result
 
 

--- a/tests/test_supportinfo_quiet_collectors_concurrency.py
+++ b/tests/test_supportinfo_quiet_collectors_concurrency.py
@@ -1,0 +1,105 @@
+# tests/test_supportinfo_quiet_collectors_concurrency.py
+"""quiet_collectors() is used by a route served by config-server under
+waitress (threads=6 in server.py), so more than one call can be in flight
+at once -- either two /supportinfo requests overlapping, or a /supportinfo
+request overlapping any other route. Both scenarios here run without flask
+or the Flask test client: they exercise supportinfo.quiet_collectors()
+directly, since it is the shared primitive both the CLI (never concurrent)
+and the endpoint (always potentially concurrent) sit on top of.
+"""
+import logging
+import threading
+
+from configurator import supportinfo
+
+_TIMEOUT = 5
+
+
+def test_overlapping_calls_do_not_leave_logging_stuck():
+    """A level-based, save/restore implementation of quiet_collectors() is
+    racy under this exact interleaving:
+
+        A enters  (saves the true original level, raises it)
+        B enters  (saves the *already-raised* level as "its" original)
+        A exits   (restores the true original -- correct, but momentary)
+        B exits   (restores "its" original, i.e. the raised level again)
+
+    B's restore re-raises the level right after A correctly lowered it,
+    and nothing ever lowers it again -- config-server's logging is silenced
+    for the rest of the process's life, with no error. The four threading
+    Events below force exactly that ordering deterministically, rather
+    than hoping timing happens to line it up.
+    """
+    root_logger = logging.getLogger()
+    original_level = root_logger.level
+
+    a_inside = threading.Event()
+    b_inside = threading.Event()
+    a_exited = threading.Event()
+    b_may_exit = threading.Event()
+
+    def thread_a():
+        with supportinfo.quiet_collectors():
+            a_inside.set()
+            assert b_inside.wait(_TIMEOUT), "thread b never entered"
+        a_exited.set()
+
+    def thread_b():
+        assert a_inside.wait(_TIMEOUT), "thread a never entered"
+        with supportinfo.quiet_collectors():
+            b_inside.set()
+            assert a_exited.wait(_TIMEOUT), "thread a never exited"
+        b_may_exit.set()
+
+    t_a = threading.Thread(target=thread_a)
+    t_b = threading.Thread(target=thread_b)
+    t_a.start()
+    t_b.start()
+    t_a.join(_TIMEOUT)
+    t_b.join(_TIMEOUT)
+
+    assert not t_a.is_alive() and not t_b.is_alive(), "threads did not finish -- deadlock"
+    assert b_may_exit.is_set(), "thread b did not complete its with-block"
+    assert root_logger.level == original_level, (
+        "root logger level was left elevated after two overlapping "
+        "quiet_collectors() calls -- config-server would stop logging "
+        "permanently"
+    )
+
+
+def test_other_thread_logs_normally_during_an_active_collection(caplog):
+    """The milder half of the same defect: even a single quiet_collectors()
+    call, if implemented by raising the *root* logger's level, silences
+    every other thread's logging for as long as collection takes (seconds,
+    since it shells out to journalctl/dpkg-query) -- not just the
+    collectors' own noise. A neighbouring route (or waitress itself, on
+    its own thread) must keep logging normally while a collection is
+    still in progress on another thread, not merely after it finishes.
+    """
+    caplog.set_level(logging.WARNING)
+
+    collector_entered = threading.Event()
+    collector_may_exit = threading.Event()
+
+    def collector_thread():
+        with supportinfo.quiet_collectors():
+            logging.getLogger("configurator.systeminfo").warning(
+                "collector noise that must be suppressed"
+            )
+            collector_entered.set()
+            assert collector_may_exit.wait(_TIMEOUT), "test main thread never released us"
+
+    t = threading.Thread(target=collector_thread)
+    t.start()
+    try:
+        assert collector_entered.wait(_TIMEOUT), "collector thread never entered quiet_collectors()"
+        # The collector thread is still inside the with-block right now.
+        logging.getLogger("configurator.server").warning(
+            "neighbouring route noise that must survive"
+        )
+    finally:
+        collector_may_exit.set()
+        t.join(_TIMEOUT)
+
+    assert "collector noise that must be suppressed" not in caplog.text
+    assert "neighbouring route noise that must survive" in caplog.text


### PR DESCRIPTION
## Summary

Follow-up review of the supportinfo endpoint work found three issues:

- **Test suite silently dead under the normal command.** `tests/test_server_supportinfo.py` imports flask unconditionally. In a checkout without flask installed, `python3 -m pytest tests/` aborted collection entirely ("Interrupted: N errors during collection"), silently skipping all 351 tests rather than just that file, with no CI to catch it. Fixed with `pytest.importorskip("flask", ...)`, matching the existing convention already used in `tests/test_extensions_handler.py`. `requirements.txt` is unchanged.
- **The endpoint and the CLI can take different collection paths without the report saying which.** `_collect_user_service_rows` uses the caller's own session bus when it happens to run as the player user, and `--machine=<user>@.host` otherwise. config-server always runs as root, so it always takes the `--machine` path; the CLI usually runs as the player user and takes the direct path. The Services section's existing detection-source note now also names which access path was used, so a report is self-describing without restructuring the collection to force one path.
- **The endpoint left collector logging unconfigured.** `main()` calls `setup_logging()` so the CLI is quiet; the endpoint didn't, so every UI request wrote the collectors' WARNING/ERROR noise into config-server's journal. Added `supportinfo.quiet_collectors()`, a context manager that raises the root logger's level only for the duration of a call and always restores it, used to wrap collection in the endpoint without touching config-server's own logging configuration or any other route.

Also documents in `get_support_info`'s docstring that it always takes the `--machine` path, since it always runs as root.

Version bumped to 2.15.10 in `_version.py`, `debian/changelog`, and the `.TH` line of `man/config-supportinfo.1`, kept in lockstep as the project requires.

## Test plan

- [x] `python3 -m pytest tests/` with flask absent: 321 passed, 3 skipped (the flask-dependent modules skip cleanly instead of aborting collection)
- [x] `python3 -m pytest tests/` with flask present (venv with flask installed): 356 passed, 0 skipped
- [x] New tests added for each fix:
  - `tests/test_pytest_collection_resilience.py` (spawns pytest subprocesses with flask hidden via `sys.modules`, asserting the rest of the suite still collects/runs; also asserts the server tests execute when flask is importable)
  - `tests/test_supportinfo_commands.py`: extended the existing same-user/`--machine` tests and the three note-format tests to assert the access-path wording
  - `tests/test_server_supportinfo.py`: asserts the root logger's effective level is raised during collection, and that a neighbouring route (`/api/v1/systeminfo`) still logs normally after a supportinfo request
- [x] Verified each new/changed assertion actually fails against the pre-fix code (reverted each source file in turn and re-ran the relevant tests)